### PR TITLE
Upgrade tagchowder latest version 2.0.18 to support attribute with literal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ The are several known bugs in the validation output.
 - the DOCTYPE tag is assumed to exist. Documents without the tag will fail to return an error.
 - Observance of afterbody mode is not implemented. Tags that appear following a body closing tag should be interpreted as within the body tag. Specs that mandate relationships between tags and ancestors related to the body tag will not account for this behavior and will return unexpected errors.
 - Attributes are de-duped by the internal html parser (the last value assigned to an attribute is the one returned to the handler). This leads to discrepancies in attribute validation to do with validation of the uniqueness of attributes and unexpected behavior in value validation.
-- Attributes are sanitized for disallowed characters. This affects operators with contextual meaning such as '{' or '['. This will affect amp-mustache tag validation.
 - Validation of URLs found within the HTML document may not return the same errors as the Node.js implementation. This stems from the fact that the internal URL library is lenient in terms of validating hostnames and characters used within the URL.
-- The parser obfuscates Unicode values, this is grievous as the amp symbol is never discovered (⚡), this package only handles the literal "amp4email."
-  Importantly, this validator prioritizes amp4email html content, enforcement of validator logic for other formats is not guaranteed.
+- This validator prioritizes amp4email html content, enforcement of validator logic for other formats is not guaranteed.
 - CSS validation does not yet configure for a max nodes value
 
 ## Contribute

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>dev.amp</groupId>
     <artifactId>validator-java</artifactId>
     <name>AMP validator Java API</name>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <description>A Java validator for the AMP Html format.</description>
     <packaging>jar</packaging>
     <url>https://github.com/ampproject/validator-java</url>
@@ -679,7 +679,7 @@
         <dependency>
             <groupId>com.yahoo.tagchowder</groupId>
             <artifactId>tagchowder.core</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.18</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/dev/amp/validator/parser/AMPHtmlParser.java
+++ b/src/main/java/dev/amp/validator/parser/AMPHtmlParser.java
@@ -92,6 +92,7 @@ public class AMPHtmlParser {
             parser.setContentHandler(handler);
             parser.setProperty(Parser.SCHEMA_PROPERTY, new HTMLSchema(true));
             parser.setFeature(Parser.DEFAULT_ATTRIBUTES_FEATURE, false);
+            parser.setFeature(Parser.AMP_VALIDATION_FEATURE, true);
             parser.parse(new InputSource(new StringReader(inputHtml)));
         } catch (IOException | SAXException ex) {
             final ValidatorProtos.ValidationResult.Builder result = handler.validationResult();

--- a/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
+++ b/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
@@ -32,6 +32,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public class AMPHtmlParserTest {
   @BeforeClass
@@ -526,7 +527,7 @@ public class AMPHtmlParserTest {
       ValidatorProtos.ValidationResult result =
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
-      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_ATTR);
+      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.TEMPLATE_IN_ATTR_NAME);
       //Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.TEMPLATE_IN_ATTR_NAME);
     } catch (final IOException ex) {
       ex.printStackTrace();
@@ -1091,7 +1092,7 @@ public class AMPHtmlParserTest {
     final StringBuilder sb = new StringBuilder();
     final InputStream is =
       Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath);
-    try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
       String currentLine;
       while ((currentLine = br.readLine()) != null) {
         sb.append(currentLine).append("\n");

--- a/src/test/resources/test-cases/attributes/testAttrDisallowedByImpliedLayout.html
+++ b/src/test/resources/test-cases/attributes/testAttrDisallowedByImpliedLayout.html
@@ -2,7 +2,7 @@
      ATTR_DISALLOWED_BY_IMPLIED_LAYOUT
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testAttrDisallowedBySpecifiedLayout.html
+++ b/src/test/resources/test-cases/attributes/testAttrDisallowedBySpecifiedLayout.html
@@ -2,7 +2,7 @@
      ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testAttrMissingRequiredExtension.html
+++ b/src/test/resources/test-cases/attributes/testAttrMissingRequiredExtension.html
@@ -2,7 +2,7 @@
      ATTR_MISSING_REQUIRED_EXTENSION
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testAttrRequiredButMissing.html
+++ b/src/test/resources/test-cases/attributes/testAttrRequiredButMissing.html
@@ -2,7 +2,7 @@
      ATTR_REQUIRED_BUT_MISSING
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testAttrValueRequiredByLayout.html
+++ b/src/test/resources/test-cases/attributes/testAttrValueRequiredByLayout.html
@@ -2,7 +2,7 @@
      ATTR_VALUE_REQUIRED_BY_LAYOUT
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testDisallowedPropertyInAttrValue.html
+++ b/src/test/resources/test-cases/attributes/testDisallowedPropertyInAttrValue.html
@@ -2,7 +2,7 @@
   DISALLOWED_PROPERTY_IN_ATTR_VALUE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testDisallowedRelativeUrl.html
+++ b/src/test/resources/test-cases/attributes/testDisallowedRelativeUrl.html
@@ -2,7 +2,7 @@
      DISALLOWED_RELATIVE_URL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testDuplicateAttribute.html
+++ b/src/test/resources/test-cases/attributes/testDuplicateAttribute.html
@@ -2,7 +2,7 @@
      DUPLICATE_ATTRIBUTE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8" charset="utf-7">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testDuplicateDimension.html
+++ b/src/test/resources/test-cases/attributes/testDuplicateDimension.html
@@ -2,7 +2,7 @@
      DUPLICATE_DIMENSION
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testImpliedLayoutInvalid.html
+++ b/src/test/resources/test-cases/attributes/testImpliedLayoutInvalid.html
@@ -2,7 +2,7 @@
      IMPLIED_LAYOUT_INVALID
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testInconsistentUnitsForWidthAndHeight.html
+++ b/src/test/resources/test-cases/attributes/testInconsistentUnitsForWidthAndHeight.html
@@ -2,7 +2,7 @@
      INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testInvalidAttrValue.html
+++ b/src/test/resources/test-cases/attributes/testInvalidAttrValue.html
@@ -2,7 +2,7 @@
      INVALID_ATTR_VALUE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <meta name="viewport">

--- a/src/test/resources/test-cases/attributes/testInvalidUrlProtocol.html
+++ b/src/test/resources/test-cases/attributes/testInvalidUrlProtocol.html
@@ -2,7 +2,7 @@
      INVALID_URL_PROTOCOL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 
 <head>
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/attributes/testMandatoryAttrMissing.html
+++ b/src/test/resources/test-cases/attributes/testMandatoryAttrMissing.html
@@ -2,7 +2,7 @@
      MANDATORY_ATTR_MISSING
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testMissingLayoutAttributes.html
+++ b/src/test/resources/test-cases/attributes/testMissingLayoutAttributes.html
@@ -2,7 +2,7 @@
      MISSING_LAYOUT_ATTRIBUTES
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testMissingUrl.html
+++ b/src/test/resources/test-cases/attributes/testMissingUrl.html
@@ -2,7 +2,7 @@
      MISSING_URL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/css/testAmpSelectorsPASS.html
+++ b/src/test/resources/test-cases/css/testAmpSelectorsPASS.html
@@ -2,7 +2,7 @@
      AMP_SELECTORS_PASS
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/css/testCSSDisallowedRelativeURL.html
+++ b/src/test/resources/test-cases/css/testCSSDisallowedRelativeURL.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_DISALLOWED_RELATIVE_URL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSExcessivelyNested.html
+++ b/src/test/resources/test-cases/css/testCSSExcessivelyNested.html
@@ -2,7 +2,7 @@
      CSS_EXCESSIVELY_NESTED
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         i{width:

--- a/src/test/resources/test-cases/css/testCSSSyntaxBadUrl.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxBadUrl.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_BAD_URL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaFeature.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaFeature.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaType.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaType.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_DISALLOWED_MEDIA_TYPE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxDisallowedPropertyValue.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxDisallowedPropertyValue.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxIncompleteDeclaration.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxIncompleteDeclaration.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_DECLARATION
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidAtRule.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidAtRule.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_INVALID_AT_RULE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidDeclaration.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidDeclaration.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_DECLARATION
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidURL.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidURL.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_URL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidUrlProtocol.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidUrlProtocol.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_URL_PROTOCOL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxMalformedMediaQuery.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxMalformedMediaQuery.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_MALFORMED_MEDIA_QUERY
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxMissingURL.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxMissingURL.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_MISSING_URL
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxStrayTrailingBackslash.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxStrayTrailingBackslash.html
@@ -3,7 +3,7 @@
      "CSS syntax error in tag '...' - stray trailing backslash."
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         /* any custom styles go here. */

--- a/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedComment.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedComment.html
@@ -3,7 +3,7 @@
      "CSS syntax error in tag '...' - unterminated comment."
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         h1 { color: red; }

--- a/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedString.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedString.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_UNTERMINATED_STRING
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         ul {"

--- a/src/test/resources/test-cases/css/testCdataViolatesBlacklist.html
+++ b/src/test/resources/test-cases/css/testCdataViolatesBlacklist.html
@@ -2,7 +2,7 @@
      CDATA_VIOLATES_BLACKLIST
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         /* any custom styles go here. */

--- a/src/test/resources/test-cases/css/testInlineStyleTooLong.html
+++ b/src/test/resources/test-cases/css/testInlineStyleTooLong.html
@@ -2,7 +2,7 @@
   INLINE_STYLE_TOO_LONG
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testStylesheetTooLong.html
+++ b/src/test/resources/test-cases/css/testStylesheetTooLong.html
@@ -19,7 +19,7 @@
   CSS_SYNTAX_INVALID_AT_RULE should be returned
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/misc/testCSSFail.html
+++ b/src/test/resources/test-cases/misc/testCSSFail.html
@@ -2,7 +2,7 @@
      testing blacklisted regex
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         /* any custom styles go here. */

--- a/src/test/resources/test-cases/misc/testCSSFail2.html
+++ b/src/test/resources/test-cases/misc/testCSSFail2.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_INVALID_AT_RULE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/misc/testCSSInlineFail.html
+++ b/src/test/resources/test-cases/misc/testCSSInlineFail.html
@@ -19,7 +19,7 @@
    should be returned
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/misc/testCSSInlinePass.html
+++ b/src/test/resources/test-cases/misc/testCSSInlinePass.html
@@ -19,7 +19,7 @@
   CSS_SYNTAX_INVALID_AT_RULE should be returned
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/misc/testCSSPass.html
+++ b/src/test/resources/test-cases/misc/testCSSPass.html
@@ -2,7 +2,7 @@
      testing blacklisted regex
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <style amp-custom>
         /* any custom styles go here. */

--- a/src/test/resources/test-cases/misc/testWarningExtensionDeprecatedVersion.html
+++ b/src/test/resources/test-cases/misc/testWarningExtensionDeprecatedVersion.html
@@ -2,7 +2,7 @@
      WARNING_EXTENSION_DEPRECATED_VERSION
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/tags/testAmpList.html
+++ b/src/test/resources/test-cases/tags/testAmpList.html
@@ -1,22 +1,17 @@
 <!--
      AMP-LIST
 -->
+<!--
+     AMP-LIST
+-->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
     <style amp4email-boilerplate>body{visibility:hidden}</style>
 </head>
 <body>
-<div class="definition-parent">
-    <!--[if (gte mso 9)]><table border="0" bgcolor="#ffffff" cellspacing="0" cellpadding="0" width="500" align="center" role="presentation" style="color: #333333; font-family: Helvetica, Arial, sans-serif; "><tr><td style="padding: 0 30px 30px 30px; "><![endif]-->
-    <amp-list id="myList" layout="container" height="425" width="500" src="https://amp.aweber.com/broadcasts/notifications?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNmekw5VE5DcnlaNlJLOVVBZGxJMXZIQVFjZE80QkVOIn0.eyJhY2NvdW50IjoiOTM0MmYwYWMtMDNlYS00ZTFhLTg3YzAtYzM0ZTllNDMyNGUzIiwiYXVkIjoiYW1wIiwiaXNzIjoiQ2Z6TDlUTkNyeVo2Uks5VUFkbEkxdkhBUWNkTzRCRU4iLCJzZW5kZXJfaWQiOiJoZWxwQGF3ZWJlci5jb20iLCJsaXN0IjoiMDhhOTM4ODEtOTMwZi00MmZmLWI1ODAtOWQ2NjBmYTc3YjcwIiwiZXhwIjoxNjA1MDMxNzcwLCJpYXQiOjE2MDM4MjIxNzAsIm1lc3NhZ2UiOiIxZWJjYWQ2MC02MTJmLTRlOTMtOTAzNy05OTgyMzg2MmQyNzMifQ.T4VeDEpV3Tukkcys7YW3XjGbVpwbUPYSEDmypzcVnT8">
-        <div placeholder style=" min-height:1000px;">Loading your Broadcast Quickstats data......</div>
-    </amp-list>
-    <!--[if (gte mso 9)]></td></tr></table><![endif]-->
-</div>
-Hello, AMP4EMAIL world.
+<p [text]="cart.p1_qty" class="qty_num">1</p>
 </body>
 </html>

--- a/src/test/resources/test-cases/tags/testDeprecatedTag.html
+++ b/src/test/resources/test-cases/tags/testDeprecatedTag.html
@@ -2,7 +2,7 @@
      DEPRECATED_TAG
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <title>Hello, AMPs</title>
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/tags/testDisallowedChildTagName.html
+++ b/src/test/resources/test-cases/tags/testDisallowedChildTagName.html
@@ -2,7 +2,7 @@
      DISALLOWED_CHILD_TAG_NAME
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testDisallowedFirstChildTagName.html
+++ b/src/test/resources/test-cases/tags/testDisallowedFirstChildTagName.html
@@ -2,7 +2,7 @@
      DISALLOWED_FIRST_CHILD_TAG_NAME
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testDisallowedScriptTag.html
+++ b/src/test/resources/test-cases/tags/testDisallowedScriptTag.html
@@ -2,7 +2,7 @@
      DISALLOWED_SCRIPT_TAG
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <meta name="viewport1">

--- a/src/test/resources/test-cases/tags/testDisallowedTag.html
+++ b/src/test/resources/test-cases/tags/testDisallowedTag.html
@@ -2,7 +2,7 @@
      DISALLOWED_TAG
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testDisallowedTagAncestor.html
+++ b/src/test/resources/test-cases/tags/testDisallowedTagAncestor.html
@@ -2,7 +2,7 @@
      DISALLOWED_TAG_ANCESTOR
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>

--- a/src/test/resources/test-cases/tags/testDuplicateUniqueTag.html
+++ b/src/test/resources/test-cases/tags/testDuplicateUniqueTag.html
@@ -2,7 +2,7 @@
      DUPLICATE_UNIQUE_TAG
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/tags/testExtensionUnused.html
+++ b/src/test/resources/test-cases/tags/testExtensionUnused.html
@@ -2,7 +2,7 @@
      EXTENSION_UNUSED
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testIncorrectNumChildTags.html
+++ b/src/test/resources/test-cases/tags/testIncorrectNumChildTags.html
@@ -2,7 +2,7 @@
      INCORRECT_NUM_CHILD_TAGS
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testInvalidJsonCdata.html
+++ b/src/test/resources/test-cases/tags/testInvalidJsonCdata.html
@@ -2,7 +2,7 @@
      INVALID_JSON_CDATA
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testMandatoryCdataMissingOrIncorrect.html
+++ b/src/test/resources/test-cases/tags/testMandatoryCdataMissingOrIncorrect.html
@@ -2,7 +2,7 @@
   MANDATORY_CDATA_MISSING_OR_INCORRECT
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate></style>

--- a/src/test/resources/test-cases/tags/testMandatoryTagAncestor.html
+++ b/src/test/resources/test-cases/tags/testMandatoryTagAncestor.html
@@ -2,7 +2,7 @@
      MANDATORY_TAG_ANCESTOR
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>

--- a/src/test/resources/test-cases/tags/testMissingRequiredExtension.html
+++ b/src/test/resources/test-cases/tags/testMissingRequiredExtension.html
@@ -2,7 +2,7 @@
      MISSING_REQUIRED_EXTENSION
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/tags/testNonWhitespaceCdataEncountered.html
+++ b/src/test/resources/test-cases/tags/testNonWhitespaceCdataEncountered.html
@@ -2,7 +2,7 @@
      NON_WHITESPACE_CDATA_ENCOUNTERED
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 
 <head>
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/tags/testSpecifiedLayoutInvalid.html
+++ b/src/test/resources/test-cases/tags/testSpecifiedLayoutInvalid.html
@@ -2,7 +2,7 @@
      SPECIFIED_LAYOUT_INVALID
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
+++ b/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
@@ -2,7 +2,7 @@
      TAG_REFERENCE_POINT_CONFLICT
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testWrongParentTag.html
+++ b/src/test/resources/test-cases/tags/testWrongParentTag.html
@@ -2,7 +2,7 @@
      WRONG_PARENT_TAG
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/templates/testTemplateInAttrName.html
+++ b/src/test/resources/test-cases/templates/testTemplateInAttrName.html
@@ -2,7 +2,7 @@
      TEMPLATE_IN_ATTR_NAME
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/templates/testTemplatePartialInAttrValue.html
+++ b/src/test/resources/test-cases/templates/testTemplatePartialInAttrValue.html
@@ -2,7 +2,7 @@
      TEMPLATE_PARTIAL_IN_ATTR_VALUE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/templates/testUnescapedTemplateInAttrValue.html
+++ b/src/test/resources/test-cases/templates/testUnescapedTemplateInAttrValue.html
@@ -2,7 +2,7 @@
      UNESCAPED_TEMPLATE_IN_ATTR_VALUE
 -->
 <!doctype html>
-<html amp4email>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>


### PR DESCRIPTION
Upgrade tagchowder verion 2.0.18 to address the followings:

Attributes are sanitized for disallowed characters. This affects operators with contextual meaning such as '{' or '['. This will affect amp-mustache tag validation.

The parser obfuscates Unicode values, this is grievous as the amp symbol is never discovered (⚡), this package only handles the literal "amp4email." Importantly, this validator prioritizes amp4email html content, enforcement of validator logic for other formats is not guaranteed.