### PR TITLE
Catch-up validator to January changes and fill in some missing business logic surrounding Selectors & Visitors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>dev.amp</groupId>
     <artifactId>validator-java</artifactId>
     <name>AMP validator Java API</name>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <description>A Java validator for the AMP Html format.</description>
     <packaging>jar</packaging>
     <url>https://github.com/ampproject/validator-java</url>

--- a/src/main/java/dev/amp/validator/AMPHtmlHandler.java
+++ b/src/main/java/dev/amp/validator/AMPHtmlHandler.java
@@ -89,7 +89,7 @@ public class AMPHtmlHandler extends DefaultHandler {
             if (validationResult.getStatus() == ValidatorProtos.ValidationResult.Status.UNKNOWN) {
                 validationResult.setStatus(ValidatorProtos.ValidationResult.Status.PASS);
             }
-            if (validationResult.getErrorsCount() > 0) {
+            if (validationResult.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL) {
                 validationResult.setStatus(ValidatorProtos.ValidationResult.Status.FAIL);
             }
         } catch (TagValidationException tve) {
@@ -173,7 +173,7 @@ public class AMPHtmlHandler extends DefaultHandler {
             this.validationResult.mergeFrom(resultForTag.getValidationResult().build());
             this.context.updateFromTagResults(encounteredTag, resultForReferencePoint, resultForTag);
 
-            if (this.validationResult.getErrorsCount() > 0
+            if (this.validationResult.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL
                     && exitCondition == ExitCondition.EXIT_ON_FIRST_ERROR) {
                 throw new ExitOnFirstErrorException();
             }

--- a/src/main/java/dev/amp/validator/AMPHtmlHandler.java
+++ b/src/main/java/dev/amp/validator/AMPHtmlHandler.java
@@ -38,6 +38,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Validation handler which accepts callbacks from HTML parser.
@@ -86,12 +87,7 @@ public class AMPHtmlHandler extends DefaultHandler {
     public void endDocument() throws SAXException {
         try {
             context.getRules().maybeEmitGlobalTagValidationErrors(context, validationResult);
-            if (validationResult.getStatus() == ValidatorProtos.ValidationResult.Status.UNKNOWN) {
-                validationResult.setStatus(ValidatorProtos.ValidationResult.Status.PASS);
-            }
-            if (validationResult.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL) {
-                validationResult.setStatus(ValidatorProtos.ValidationResult.Status.FAIL);
-            }
+            setValidationResultStatus();
         } catch (TagValidationException tve) {
             /** ignore */
         }
@@ -171,6 +167,7 @@ public class AMPHtmlHandler extends DefaultHandler {
                     resultForTag.getValidationResult());
 
             this.validationResult.mergeFrom(resultForTag.getValidationResult().build());
+
             this.context.updateFromTagResults(encounteredTag, resultForReferencePoint, resultForTag);
 
             if (this.validationResult.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL
@@ -276,6 +273,24 @@ public class AMPHtmlHandler extends DefaultHandler {
                 params,
                 refPointSpec.getReferencePoints().parentSpecUrl(),
                 validationResult);
+    }
+
+    /**
+     * If the errors list contain at least one ValidatorProtos.ValidationError.Severity.ERROR,
+     * set the status to ValidatorProtos.ValidationResult.Status.FAIL.
+     */
+    private void setValidationResultStatus() {
+        validationResult.setStatus(ValidatorProtos.ValidationResult.Status.PASS);
+        if (validationResult.getErrorsList().isEmpty()) {
+            return;
+        }
+        Optional<ValidatorProtos.ValidationError> validationError =
+                validationResult.getErrorsList().stream()
+                        .filter(r -> r.getSeverity() == ValidatorProtos.ValidationError.Severity.ERROR)
+                        .findFirst();
+        if (validationError.isPresent()) {
+            validationResult.setStatus(ValidatorProtos.ValidationResult.Status.FAIL);
+        }
     }
 
     /**

--- a/src/main/java/dev/amp/validator/CdataMatcher.java
+++ b/src/main/java/dev/amp/validator/CdataMatcher.java
@@ -326,7 +326,7 @@ public class CdataMatcher {
         stylesheet.accept(invalidRuleVisitor);
 
         // Validate the allowed CSS declarations (eg: `background-color`)
-        if (maybeDocCssSpec != null && !maybeDocCssSpec.getSpec().getAllowAllDeclarationInStyleTag()) {
+        if (maybeDocCssSpec != null && !maybeDocCssSpec.getSpec().getAllowAllDeclarationInStyle()) {
             final InvalidDeclVisitor invalidDeclVisitor =
                     new InvalidDeclVisitor(maybeDocCssSpec, context, validationResult);
             stylesheet.accept(invalidDeclVisitor);

--- a/src/main/java/dev/amp/validator/CdataMatcher.java
+++ b/src/main/java/dev/amp/validator/CdataMatcher.java
@@ -50,6 +50,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static dev.amp.validator.utils.TagSpecUtils.getTagDescriptiveName;
+
 /**
  * CdataMatcher maintains a constraint to check which an opening tag
  * introduces: a tag's cdata matches constraints set by it's cdata
@@ -328,7 +330,7 @@ public class CdataMatcher {
         // Validate the allowed CSS declarations (eg: `background-color`)
         if (maybeDocCssSpec != null && !maybeDocCssSpec.getSpec().getAllowAllDeclarationInStyle()) {
             final InvalidDeclVisitor invalidDeclVisitor =
-                    new InvalidDeclVisitor(maybeDocCssSpec, context, validationResult);
+                    new InvalidDeclVisitor(maybeDocCssSpec, context, getTagDescriptiveName(this.getTagSpec()), validationResult);
             stylesheet.accept(invalidDeclVisitor);
         }
 

--- a/src/main/java/dev/amp/validator/CdataMatcher.java
+++ b/src/main/java/dev/amp/validator/CdataMatcher.java
@@ -42,6 +42,7 @@ import dev.amp.validator.utils.UrlUtils;
 import dev.amp.validator.visitor.InvalidDeclVisitor;
 import dev.amp.validator.visitor.InvalidRuleVisitor;
 import dev.amp.validator.visitor.MediaQueryVisitor;
+import dev.amp.validator.visitor.SelectorSpecVisitor;
 import org.xml.sax.Locator;
 
 import javax.annotation.Nonnull;
@@ -247,6 +248,10 @@ public class CdataMatcher {
             }
         }
 
+        if (cssSpec.hasSelectorSpec()) {
+            this.matchSelectors(stylesheet, cssSpec.getSelectorSpec(), cssErrors);
+        }
+
         if (cssSpec.getValidateAmp4Ads()) {
             CssSpecUtils.validateAmp4AdsCss(stylesheet, cssErrors);
         }
@@ -344,7 +349,6 @@ public class CdataMatcher {
      * @param spec        the spec to validate against
      * @param errorBuffer the errors collection to populate
      * @throws CssValidationException css validation exception.
-     * @private
      */
     private void matchMediaQuery(@Nonnull final Stylesheet stylesheet,
                                  @Nonnull final ValidatorProtos.MediaQuerySpec spec,
@@ -382,6 +386,21 @@ public class CdataMatcher {
             }
         }
     }
+
+    /**
+     * Matches the provided stylesheet against a SelectorSpec
+     * @param stylesheet the stylesheet to match
+     * @param  spec the spec to match against
+     * @param  errorBuffer the error buffer to populate
+     * @throws CssValidationException
+     */
+    private void matchSelectors(@Nonnull final Stylesheet stylesheet,
+                                @Nonnull final ValidatorProtos.SelectorSpec spec,
+                                @Nonnull final List<ErrorToken> errorBuffer) throws CssValidationException {
+        final SelectorSpecVisitor visitor = new SelectorSpecVisitor(spec, errorBuffer);
+        stylesheet.accept(visitor);
+    }
+
 
     /**
      * @return lineCol of CdataMatcher

--- a/src/main/java/dev/amp/validator/ParsedValidatorRules.java
+++ b/src/main/java/dev/amp/validator/ParsedValidatorRules.java
@@ -79,6 +79,7 @@ public class ParsedValidatorRules {
         typeIdentifiers.put("actions", 0);
         typeIdentifiers.put("transformed", 0);
         typeIdentifiers.put("data-ampdevmode", 0);
+        typeIdentifiers.put("data-css-strict", 0);
 
         expandExtensionSpec();
 
@@ -404,11 +405,11 @@ public class ParsedValidatorRules {
                         validationResult.addTypeIdentifier(typeIdentifier);
                         context.recordTypeIdentifier(typeIdentifier);
                     }
-                    // The type identifier "actions" and "transformed" are not considered
-                    // mandatory unlike other type identifiers.
-                    if (!typeIdentifier.equals("actions")
-                            && !typeIdentifier.equals("transformed")
-                            && !typeIdentifier.equals("data-ampdevmode")) {
+                    // The type identifier "transformed" is not considered mandatory
+                    // unlike other type identifiers.
+                    if (!typeIdentifier.equals("transformed")
+                            && !typeIdentifier.equals("data-ampdevmode")
+                            && !typeIdentifier.equals("data-css-strict")) {
                         hasMandatoryTypeIdentifier = true;
                     }
                     // The type identifier "transformed" has restrictions on it's value.

--- a/src/main/java/dev/amp/validator/ParsedValidatorRules.java
+++ b/src/main/java/dev/amp/validator/ParsedValidatorRules.java
@@ -184,6 +184,7 @@ public class ParsedValidatorRules {
      * a pattern syntax exception occurs, escape curly brace and recompile.
      * @param regexMap the regex map
      * @param regex the regex
+     * @param isFullMatch if we are looking for a full match
      * @return the pattern
      */
     public Pattern findOrCreatePattern(@Nonnull final Map<String, Pattern> regexMap, @Nonnull final String regex, final boolean isFullMatch) {

--- a/src/main/java/dev/amp/validator/selector/AttrSelector.java
+++ b/src/main/java/dev/amp/validator/selector/AttrSelector.java
@@ -22,6 +22,7 @@
 
 package dev.amp.validator.selector;
 
+import dev.amp.validator.css.CssValidationException;
 import dev.amp.validator.css.TokenType;
 import dev.amp.validator.visitor.SelectorVisitor;
 
@@ -68,7 +69,7 @@ public class AttrSelector extends Selector {
      * visits a selector
      * @param visitor a SelectorVisitor instance
      */
-    public void accept(@Nonnull final SelectorVisitor visitor) {
+    public void accept(@Nonnull final SelectorVisitor visitor) throws CssValidationException {
         visitor.visitAttrSelector(this);
     }
 
@@ -79,6 +80,14 @@ public class AttrSelector extends Selector {
     @Override
     public TokenType getTokenType() {
         return TokenType.ATTR_SELECTOR;
+    }
+
+    /**
+     * get token type
+     * @return the token type
+     */
+    public String getAttrName() {
+        return this.attrName;
     }
 
     /**

--- a/src/main/java/dev/amp/validator/selector/PseudoSelector.java
+++ b/src/main/java/dev/amp/validator/selector/PseudoSelector.java
@@ -23,6 +23,7 @@
 package dev.amp.validator.selector;
 
 import com.steadystate.css.parser.Token;
+import dev.amp.validator.css.CssValidationException;
 import dev.amp.validator.css.TokenType;
 import dev.amp.validator.visitor.SelectorVisitor;
 
@@ -71,8 +72,9 @@ public class PseudoSelector extends Selector {
     /**
      * visits a selector
      * @param visitor a SelectorVisitor instance
+     * @throws CssValidationException
      */
-    public void accept(@Nonnull final SelectorVisitor visitor) {
+    public void accept(@Nonnull final SelectorVisitor visitor) throws CssValidationException {
         visitor.visitPseudoSelector(this);
     }
 
@@ -83,6 +85,22 @@ public class PseudoSelector extends Selector {
     @Override
     public TokenType getTokenType() {
         return TokenType.PSEUDO_SELECTOR;
+    }
+
+    /**
+     * if is a class
+     * @return true if isClass
+     */
+    public boolean isClass() {
+        return isClass;
+    }
+
+    /**
+     * getter for name
+     * @return the name of selector
+     */
+    public String getName() {
+        return name;
     }
 
     /**

--- a/src/main/java/dev/amp/validator/selector/Selector.java
+++ b/src/main/java/dev/amp/validator/selector/Selector.java
@@ -22,6 +22,7 @@
 
 package dev.amp.validator.selector;
 
+import dev.amp.validator.css.CssValidationException;
 import dev.amp.validator.css.Token;
 import dev.amp.validator.visitor.SelectorVisitor;
 
@@ -40,5 +41,5 @@ public abstract class Selector extends Token {
     public abstract void forEachChild(Consumer<Selector> selector);
 
     /** @param visitor a SelectorVisitor instance */
-    public abstract void accept(SelectorVisitor visitor);
+    public abstract void accept(SelectorVisitor visitor) throws CssValidationException;
 }

--- a/src/main/java/dev/amp/validator/selector/SimpleSelectorSequence.java
+++ b/src/main/java/dev/amp/validator/selector/SimpleSelectorSequence.java
@@ -48,11 +48,10 @@ public class SimpleSelectorSequence extends Selector {
     }
 
     @Override
-    public void forEachChild(final Consumer<Selector> selector) {
-//        lambda(this.typeSelector);
-//        for (const other of this.otherSelectors) {
-//            lambda(other);
-//        }
+    public void forEachChild(final Consumer<Selector> lambda) {
+        for (final Selector selector : this.otherSelectors) {
+            lambda.accept(selector);
+        }
     }
 
     @Override

--- a/src/main/java/dev/amp/validator/utils/SelectorUtils.java
+++ b/src/main/java/dev/amp/validator/utils/SelectorUtils.java
@@ -104,7 +104,7 @@ public final class SelectorUtils {
      * @return if this is a delim char
      */
     public static boolean isDelim(@Nonnull final com.steadystate.css.parser.Token token, @Nonnull final String delimChar) {
-        return getTokenType(token) == TokenType.DELIM && (token.getValue()).equals(delimChar);
+        return getTokenType(token) == TokenType.DELIM && (token.image).equals(delimChar);
     }
 
     /**

--- a/src/main/java/dev/amp/validator/utils/TagSpecUtils.java
+++ b/src/main/java/dev/amp/validator/utils/TagSpecUtils.java
@@ -899,7 +899,8 @@ public final class TagSpecUtils {
     public static final List AMP4ADS_IDENTIFIERS = Arrays.asList("\u26a14ads", "\u26a1\ufe0f4ads", "amp4ads", "data-ampdevmode");
 
     /** List identifiers for AMP4EMAIL format. */
-    public static final List AMP4EMAIL_IDENTIFIERS = Arrays.asList("\u26a14email", "\u26a1\ufe0f4email", "amp4email", "data-ampdevmode");
+    public static final List AMP4EMAIL_IDENTIFIERS = Arrays.asList("\u26a14email", "\u26a1\ufe0f4email", "amp4email",
+            "data-ampdevmode", "data-css-strict");
 
     /** List identifiers for ACTIONS format. */
     public static final List ACTIONS_IDENTIFIERS = Arrays.asList("\u26a1", "\u26a1\ufe0f", "amp", "actions", "data-ampdevmode");

--- a/src/main/java/dev/amp/validator/utils/TagSpecUtils.java
+++ b/src/main/java/dev/amp/validator/utils/TagSpecUtils.java
@@ -101,6 +101,20 @@ public final class TagSpecUtils {
     }
 
     /**
+     * For creating error messages, we either find the descriptiveName in the tag
+     * spec or fall back to the tagName.
+     *
+     * @param tagSpec TagSpec instance from the validator.protoscii file.
+     * @return return the descriptive tag spec name.
+     * @private
+     */
+    public static String getTagDescriptiveName(@Nonnull final ValidatorProtos.TagSpec tagSpec) {
+        return tagSpec.hasDescriptiveName() ? tagSpec.getDescriptiveName()
+                : tagSpec.getTagName().toLowerCase();
+    }
+
+
+    /**
      * We only track (that is, add them to Context.RecordTagspecValidated) validated
      * tagspecs as necessary. That is, if it's needed for document scope validation:
      * - Mandatory tags

--- a/src/main/java/dev/amp/validator/visitor/InvalidDeclVisitor.java
+++ b/src/main/java/dev/amp/validator/visitor/InvalidDeclVisitor.java
@@ -53,7 +53,7 @@ public class InvalidDeclVisitor implements RuleVisitor {
         if (cssDeclaration.getValueCaseiList().size() > 0) {
             boolean hasValidValue = false;
             for (final String value : cssDeclaration.getValueCaseiList()) {
-                if (firstIdent.toLowerCase() == value) {
+                if (firstIdent.toLowerCase().equals(value)) {
                     hasValidValue = true;
                     break;
                 }

--- a/src/main/java/dev/amp/validator/visitor/InvalidDeclVisitor.java
+++ b/src/main/java/dev/amp/validator/visitor/InvalidDeclVisitor.java
@@ -8,6 +8,7 @@ import dev.amp.validator.css.ParsedDocCssSpec;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class InvalidDeclVisitor implements RuleVisitor {
 
@@ -17,13 +18,15 @@ public class InvalidDeclVisitor implements RuleVisitor {
      * @param spec the parsed doc css spec
      * @param context the context
      * @param result validation result
+     * @param tagDescriptiveName the descriptive name of a declaration
      */
-    public InvalidDeclVisitor(@Nonnull final ParsedDocCssSpec spec, @Nonnull final Context context,
+    public InvalidDeclVisitor(@Nonnull final ParsedDocCssSpec spec, @Nonnull final Context context, final String tagDescriptiveName,
                               @Nonnull final ValidatorProtos.ValidationResult.Builder result) {
         super();
         this.spec = spec;
         this.context = context;
         this.result = result;
+        this.tagDescriptiveName = tagDescriptiveName;
     }
 
     /**
@@ -31,8 +34,10 @@ public class InvalidDeclVisitor implements RuleVisitor {
      *
      * @param declaration the declaration to visit
      */
-    public void visitDeclaration(final Declaration declaration) {
-        if (this.spec.getCssDeclarationByName().get(declaration.getName()) != null) {
+    public void visitDeclaration(@Nonnull final Declaration declaration) {
+        final ValidatorProtos.CssDeclaration cssDeclaration = this.spec.getCssDeclarationByName().get(declaration.getName());
+        final String firstIdent = declaration.firstIdent();
+        if (cssDeclaration == null) {
             List<String> params = new ArrayList<>();
             params.add(declaration.getName());
             params.add("style amp-custom");
@@ -43,14 +48,56 @@ public class InvalidDeclVisitor implements RuleVisitor {
                     context.getLineCol().getColumnNumber() + declaration.getCol(),
                     params, this.spec.getSpec().getSpecUrl(),
                     this.result);
+            return;
+        }
+        if (cssDeclaration.getValueCaseiList().size() > 0) {
+            boolean hasValidValue = false;
+            for (final String value : cssDeclaration.getValueCaseiList()) {
+                if (firstIdent.toLowerCase() == value) {
+                    hasValidValue = true;
+                    break;
+                }
+            }
+            if (!hasValidValue) {
+                // Declaration value not allowed.
+                List<String> params = new ArrayList<>();
+                params.add(this.tagDescriptiveName);
+                params.add(declaration.getName());
+                params.add(firstIdent);
+
+                this.context.addError(
+                        ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE,
+                        context.getLineCol().getLineNumber() + declaration.getLine(),
+                        context.getLineCol().getColumnNumber() + declaration.getCol(),
+                        params,
+                        this.spec.getSpec().getSpecUrl(), this.result);
+            } else if (!cssDeclaration.hasValueRegexCasei()) {
+                final Pattern valueRegex = this.context.getRules().getFullMatchCaseiRegex((cssDeclaration.getValueRegexCasei()));
+                if (!valueRegex.matcher(firstIdent).matches()) {
+                    List<String> params = new ArrayList<>();
+                    params.add(this.tagDescriptiveName);
+                    params.add(declaration.getName());
+                    params.add(firstIdent);
+
+                    this.context.addError(
+                            ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE,
+                            context.getLineCol().getLineNumber() + declaration.getLine(),
+                            context.getLineCol().getColumnNumber() + declaration.getCol(),
+                            params, this.spec.getSpec().getSpecUrl(), this.result);
+                }
+            }
         }
     }
-
 
     /**
      * ParsedDocCssSpec associated to Visitor
      */
     private final ParsedDocCssSpec spec;
+
+    /**
+     * descriptive name associated to Visitor
+     */
+    private final String tagDescriptiveName;
 
     /**
      * reference to Context

--- a/src/main/java/dev/amp/validator/visitor/SelectorSpecVisitor.java
+++ b/src/main/java/dev/amp/validator/visitor/SelectorSpecVisitor.java
@@ -1,5 +1,7 @@
 package dev.amp.validator.visitor;
 
+import dev.amp.validator.ValidatorProtos;
+import dev.amp.validator.css.CssValidationException;
 import dev.amp.validator.css.ErrorToken;
 import dev.amp.validator.selector.AttrSelector;
 import dev.amp.validator.selector.ClassSelector;
@@ -11,7 +13,10 @@ import dev.amp.validator.selector.SimpleSelectorSequence;
 import dev.amp.validator.selector.TypeSelector;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
+
+import static dev.amp.validator.css.CssTokenUtil.copyPosTo;
 
 /**
  * A visitor for selector.
@@ -21,11 +26,16 @@ import java.util.List;
  */
 
 public class SelectorSpecVisitor extends SelectorVisitor {
+
     /**
-     * @param errors an array of ErrorTokens
+     * @param errorBuffer an array of ErrorTokens
+     * @param spec the underlying selector spec
      */
-    public SelectorSpecVisitor(@Nonnull final List<ErrorToken> errors) {
-        super(errors);
+    public SelectorSpecVisitor(@Nonnull final ValidatorProtos.SelectorSpec spec,
+                               @Nonnull final List<ErrorToken> errorBuffer) {
+        super(errorBuffer);
+        this.selectorSpec = spec;
+        this.errorBuffer = errorBuffer;
     }
 
     @Override
@@ -36,12 +46,63 @@ public class SelectorSpecVisitor extends SelectorVisitor {
     public void visitIdSelector(@Nonnull final IdSelector idSelector) {
     }
 
+    /**
+     * @param attrSelector to visit
+     * @override
+     */
     @Override
-    public void visitAttrSelector(@Nonnull final AttrSelector attrSelector) {
+    public void visitAttrSelector(@Nonnull final AttrSelector attrSelector) throws CssValidationException {
+        for (final String allowedName : this.selectorSpec.getAttributeNameList()) {
+            if (allowedName.equals("*") || allowedName.equals(attrSelector.getAttrName())) {
+                return;
+            }
+        }
+
+        final List<String> params = new ArrayList<>();
+        params.add("");
+        params.add(attrSelector.getAttrName());
+
+        final ErrorToken errorToken = new ErrorToken(
+                ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_ATTR_SELECTOR,
+                params);
+        copyPosTo(attrSelector, errorToken);
+        this.errorBuffer.add(errorToken);
     }
 
     @Override
-    public void visitPseudoSelector(@Nonnull final PseudoSelector pseudoSelector) {
+    public void visitPseudoSelector(@Nonnull final PseudoSelector pseudoSelector) throws CssValidationException {
+        if (pseudoSelector.isClass()) {  // pseudo-class
+            for (final String allowedPseudoClass : this.selectorSpec.getPseudoClassList()) {
+                if (allowedPseudoClass.equals("*") || allowedPseudoClass.equals(pseudoSelector.getName())) {
+                    return;
+                }
+            }
+            final List<String> params = new ArrayList<>();
+            params.add("");
+            params.add(pseudoSelector.getName());
+
+            final ErrorToken errorToken = new ErrorToken(
+                    ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_PSEUDO_CLASS,
+                    params);
+            copyPosTo(pseudoSelector, errorToken);
+            this.errorBuffer.add(errorToken);
+        } else {  // pseudo-element
+            for (final String allowedPseudoElement : this.selectorSpec.getPseudoElementList()) {
+                if (allowedPseudoElement.equals("*")
+                        || allowedPseudoElement.equals(pseudoSelector.getName())) {
+                    return;
+                }
+            }
+            final List<String> params = new ArrayList<>();
+            params.add("");
+            params.add(pseudoSelector.getName());
+
+            final ErrorToken errorToken = new ErrorToken(
+                    ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_PSEUDO_ELEMENT,
+                    params);
+            copyPosTo(pseudoSelector, errorToken);
+            this.errorBuffer.add(errorToken);
+        }
     }
 
     @Override
@@ -59,4 +120,14 @@ public class SelectorSpecVisitor extends SelectorVisitor {
     @Override
     public void visitSelectorsGroup(@Nonnull final Selector selector) {
     }
+
+    /**
+     * underlying selector spec
+     */
+    private final ValidatorProtos.SelectorSpec selectorSpec;
+
+    /**
+     * error buffer
+     */
+    private final List<ErrorToken> errorBuffer;
 }

--- a/src/main/java/dev/amp/validator/visitor/SelectorVisitor.java
+++ b/src/main/java/dev/amp/validator/visitor/SelectorVisitor.java
@@ -78,7 +78,7 @@ public abstract class SelectorVisitor implements RuleVisitor {
         final TokenStream tokenStream = new TokenStream(qualifiedRule.getPrelude());
         tokenStream.consume();
 
-        SelectorsGroup maybeSelector;
+        Selector maybeSelector;
         try {
             maybeSelector = parseASelectorsGroup(tokenStream);
         } catch (final SelectorException selectorException) {
@@ -86,7 +86,9 @@ public abstract class SelectorVisitor implements RuleVisitor {
             return;
         }
 
-        final ArrayDeque<Selector> toVisit = maybeSelector.getElements();
+        ArrayDeque<Selector> selectorQueue = new ArrayDeque<>();
+        selectorQueue.push(maybeSelector);
+        final ArrayDeque<Selector> toVisit = selectorQueue;
 
         while (!toVisit.isEmpty()) {
 
@@ -107,7 +109,7 @@ public abstract class SelectorVisitor implements RuleVisitor {
      * @param tokenStream to work with
      * @return selectors group from top of stream
      */
-    public static SelectorsGroup parseASelectorsGroup(@Nonnull final TokenStream tokenStream) throws CssValidationException, SelectorException {
+    public static Selector parseASelectorsGroup(@Nonnull final TokenStream tokenStream) throws CssValidationException, SelectorException {
         if (!isSimpleSelectorSequenceStart(tokenStream.current())) {
             final List<String> params = new ArrayList<>();
             params.add("style");
@@ -148,10 +150,7 @@ public abstract class SelectorVisitor implements RuleVisitor {
                 throw new SelectorException(errorToken);
             }
             if (elements.size() == 1) {
-                if (elements.getFirst() instanceof SelectorsGroup) {
-                    return (SelectorsGroup) elements.getFirst();
-                }
-                throw new CssValidationException("Expected SelectorsGroup as first element of Selectors collection.");
+                return elements.getFirst();
             }
             return (SelectorsGroup) copyPosTo(start, new SelectorsGroup(elements));
         }
@@ -173,13 +172,13 @@ public abstract class SelectorVisitor implements RuleVisitor {
      *
      * @param attrSelector
      */
-    public abstract void visitAttrSelector(@Nonnull AttrSelector attrSelector);
+    public abstract void visitAttrSelector(@Nonnull AttrSelector attrSelector) throws CssValidationException;
 
     /**
      *
      * @param pseudoSelector
      */
-    public abstract void visitPseudoSelector(@Nonnull PseudoSelector pseudoSelector);
+    public abstract void visitPseudoSelector(@Nonnull PseudoSelector pseudoSelector) throws CssValidationException;
 
     /**
      *

--- a/src/main/proto/validator.proto
+++ b/src/main/proto/validator.proto
@@ -360,16 +360,16 @@ message CdataSpec {
 message AmpLayout {
   // NEXT AVAILABLE TAG: 10
   enum Layout {
-    UNKNOWN = 0;
-    NODISPLAY = 1;
-    FIXED = 2;
-    FIXED_HEIGHT = 3;
-    RESPONSIVE = 4;
     CONTAINER = 5;
     FILL = 6;
+    FIXED = 2;
+    FIXED_HEIGHT = 3;
     FLEX_ITEM = 7;
     FLUID = 8;
     INTRINSIC = 9;
+    NODISPLAY = 1;
+    RESPONSIVE = 4;
+    UNKNOWN = 0;
   }
   // Specifies which layouts are supported by this element.
   repeated Layout supported_layouts = 1;
@@ -764,11 +764,9 @@ message DocCssSpec {
   // If provided, a URL linking to a section / sentence in the AMP HTML spec.
   optional string max_bytes_spec_url = 8;
 
-  // Declaration allow-lists were added when style attribute validation was
-  // implementented. Therefore older style tags do not enforce an allowlist
-  // of declarations. If true, all declarations are allowed in style tags,
-  // regardless of the contents of the `declaration` list.
-  optional bool allow_all_declaration_in_style_tag = 10 [default = false];
+  // If true, all declarations are allowed in style tags and inline style
+  // attributes, regardless of the contents of the `declaration` list.
+  optional bool allow_all_declaration_in_style = 10 [default = false];
   // If true, all variants of declarations that are vendor prefixes are allowed.
   // for example, if `gradient` is an allowed declaration and this is true, then
   // `-webkit-gradient` is also an allowed declaration.
@@ -854,7 +852,7 @@ message ValidationError {
     // DO NOT REASSIGN the previously used values 2, 3.
   }
   optional Severity severity = 6 [default = ERROR];
-  // NEXT AVAILABLE TAG: 120
+  // NEXT AVAILABLE TAG: 121
   enum Code {
     UNKNOWN_CODE = 0;
     INVALID_DOCTYPE_HTML = 111;
@@ -935,6 +933,7 @@ message ValidationError {
     INVALID_UTF8 = 96;
     DOCUMENT_SIZE_LIMIT_EXCEEDED = 108;
     DEV_MODE_ONLY = 109;
+    AMP_EMAIL_MISSING_STRICT_CSS_ATTR = 120;
     VALUE_SET_MISMATCH = 110;
 
     CSS_SYNTAX_INVALID_AT_RULE = 29;

--- a/src/main/resources/validator-all.protoascii
+++ b/src/main/resources/validator-all.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1132
+spec_file_revision: 1155
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -66,6 +66,8 @@ tags: {
   # on existing AMP documents.
   attrs: {
     name: "lang"
+    deprecation: "html"
+    deprecation_url: "https://github.com/ampproject/amphtml/issues/25926"
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
@@ -338,9 +340,9 @@ tags: {
                  "https://fonts\\.googleapis\\.com/earlyaccess/.*\\.css|"
                  "https://maxcdn\\.bootstrapcdn\\.com/font-awesome/"
                  "([0-9]+\\.?)+/css/font-awesome\\.min\\.css(\\?.*)?|"
-                 "https://(use|pro)\\.fontawesome\\.com/releases/v([0-9]+\\.?)+"
+                 "https://(use|pro|kit)\\.fontawesome\\.com/releases/v([0-9]+\\.?)+"
                  "/css/[0-9a-zA-Z-]+\\.css|"
-                 "https://(use|pro)\\.fontawesome\\.com/[0-9a-zA-Z-]+\\.css|"
+                 "https://(use|pro|kit)\\.fontawesome\\.com/[0-9a-zA-Z-]+\\.css|"
                  "https://use\\.typekit\\.net/[\\w\\p{L}\\p{N}_]+\\.css"
   }
   attrs: { name: "integrity" }  # SRI attribute (https://www.w3.org/TR/SRI/)
@@ -1704,7 +1706,8 @@ tags: {
 
 # 4.7 Embedded Content
 # AMP HTML allows embedded content only via its own tags (e.g. amp-img), with
-# the exception of tags inside of a <noscript> ancestor and transformed amp-img.
+# the exception of tags inside of a <noscript> or <amp-story-player> ancestor
+# and transformed amp-img.
 # 4.7.1 The img element
 tags: {
   html_format: AMP  # Disallowed in AMP4ADS because <noscript> is disallowed.
@@ -2137,831 +2140,8 @@ tags: {
   spec_url: "https://amp.dev/documentation/components/amp-ima-video/"
 }
 
-
 # 4.7.15 SVG
-# We allow some limited embedded SVG tags. We do not allow inline styles
-# or embedding any external resources.
-# Attribute lists: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
-attr_lists: {
-  name: "svg-conditional-processing-attributes"
-  attrs: { name: "requiredextensions" }
-  attrs: { name: "requiredfeatures" }
-  attrs: { name: "systemlanguage" }
-}
-attr_lists: {
-  name: "svg-core-attributes"
-  attrs: { name: "xml:lang" }
-  attrs: { name: "xml:space" }
-  attrs: { name: "xmlns" }
-  attrs: { name: "xmlns:xlink" }
-}
-attr_lists: {
-  name: "svg-filter-primitive-attributes"
-  attrs: { name: "height" }
-  attrs: { name: "result" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-}
-attr_lists: {
-  name: "svg-presentation-attributes"
-  attrs: { name: "alignment-baseline" }
-  attrs: { name: "baseline-shift" }
-  attrs: { name: "clip" }
-  attrs: { name: "clip-path" }
-  attrs: { name: "clip-rule" }
-  attrs: { name: "color" }
-  attrs: { name: "color-interpolation" }
-  attrs: { name: "color-interpolation-filters" }
-  attrs: { name: "color-profile" }
-  attrs: { name: "color-rendering" }
-  attrs: { name: "cursor" }
-  attrs: { name: "direction" }
-  attrs: { name: "display" }
-  attrs: { name: "dominant-baseline" }
-  attrs: { name: "enable-background" }
-  attrs: { name: "fill" }
-  attrs: { name: "fill-opacity" }
-  attrs: { name: "fill-rule" }
-  attrs: { name: "filter" }
-  attrs: { name: "flood-color" }
-  attrs: { name: "flood-opacity" }
-  attrs: { name: "focusable" }
-  attrs: { name: "font-family" }
-  attrs: { name: "font-size" }
-  attrs: { name: "font-size-adjust" }
-  attrs: { name: "font-stretch" }
-  attrs: { name: "font-style" }
-  attrs: { name: "font-variant" }
-  attrs: { name: "font-weight" }
-  attrs: { name: "glyph-orientation-horizontal" }
-  attrs: { name: "glyph-orientation-vertical" }
-  attrs: { name: "image-rendering" }
-  attrs: { name: "kerning" }
-  attrs: { name: "letter-spacing" }
-  attrs: { name: "lighting-color" }
-  attrs: { name: "marker-end" }
-  attrs: { name: "marker-mid" }
-  attrs: { name: "marker-start" }
-  attrs: { name: "mask" }
-  attrs: { name: "opacity" }
-  attrs: { name: "overflow" }
-  attrs: { name: "pointer-events" }
-  attrs: { name: "shape-rendering" }
-  attrs: { name: "stop-color" }
-  attrs: { name: "stop-opacity" }
-  attrs: { name: "stroke" }
-  attrs: { name: "stroke-dasharray" }
-  attrs: { name: "stroke-dashoffset" }
-  attrs: { name: "stroke-linecap" }
-  attrs: { name: "stroke-linejoin" }
-  attrs: { name: "stroke-miterlimit" }
-  attrs: { name: "stroke-opacity" }
-  attrs: { name: "stroke-width" }
-  attrs: { name: "text-anchor" }
-  attrs: { name: "text-decoration" }
-  attrs: { name: "text-rendering" }
-  attrs: { name: "unicode-bidi" }
-  attrs: { name: "vector-effect" }
-  attrs: { name: "visibility" }
-  attrs: { name: "word-spacing" }
-  attrs: { name: "writing-mode" }
-}
-attr_lists: {
-  name: "svg-transfer-function-attributes"
-  attrs: { name: "amplitude" }
-  attrs: { name: "exponent" }
-  attrs: { name: "intercept" }
-  attrs: { name: "offset" }
-  attrs: { name: "slope" }
-  attrs: { name: "table" }
-  attrs: { name: "tablevalues" }
-}
-attr_lists: {
-  name: "svg-xlink-attributes"
-  attrs: { name: "xlink:actuate" }
-  attrs: { name: "xlink:arcrole" }
-  attrs: {
-    name: "xlink:href"
-    # xlink:href is deprecated since SVG2 in favor of href.
-    alternative_names: "href"
-    value_url: {
-      protocol: "http"
-      protocol: "https"
-      allow_empty: false
-    }
-  }
-  attrs: { name: "xlink:role" }
-  attrs: { name: "xlink:show" }
-  attrs: { name: "xlink:title" }
-  attrs: { name: "xlink:type" }
-}
-# Style attributes are broadly disallowed, but specifically allowed
-# within SVG as SVG are commonly generated by tools.
-attr_lists: {
-  name: "svg-style-attr"
-  attrs: {
-    name: "style"
-    # `style` attribute value validated against Document Level CSS rules defined
-    # in validator-css.protoascii.
-    value_doc_svg_css: true
-  }
-}
-
-# Basics
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "G"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "GLYPH"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "arabic-form" }
-  attrs: { name: "d" }
-  attrs: { name: "glyph-name" }
-  attrs: { name: "horiz-adv-x" }
-  attrs: { name: "orientation" }
-  attrs: { name: "unicode" }
-  attrs: { name: "vert-adv-y" }
-  attrs: { name: "vert-origin-x" }
-  attrs: { name: "vert-origin-y" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "GLYPHREF"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "dx" }
-  attrs: { name: "dy" }
-  attrs: { name: "format" }
-  attrs: { name: "glyphref" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "IMAGE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "preserveaspectratio" }
-  attrs: { name: "transform" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "xlink:actuate" }
-  attrs: { name: "xlink:arcrole" }
-  attrs: {
-    name: "xlink:href"
-    # xlink:href is deprecated since SVG2 in favor of href.
-    alternative_names: "href"
-    value_url: {
-      protocol: "data"
-      protocol: "http"
-      protocol: "https"
-      allow_empty: false
-    }
-    # Inline SVGs execute in a different context and can affect page elements.
-    disallowed_value_regex: "(^|\\s)data:image\\/svg\\+xml"
-  }
-  attrs: { name: "xlink:role" }
-  attrs: { name: "xlink:show" }
-  attrs: { name: "xlink:title" }
-  attrs: { name: "xlink:type" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "MARKER"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "markerheight" }
-  attrs: { name: "markerunits" }
-  attrs: { name: "markerwidth" }
-  attrs: { name: "orient" }
-  attrs: { name: "preserveaspectratio" }
-  attrs: { name: "refx" }
-  attrs: { name: "refy" }
-  attrs: { name: "transform" }
-  attrs: { name: "viewbox" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "METADATA"
-  mandatory_ancestor: "SVG"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "PATH"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "d" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "pathlength" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "SOLIDCOLOR"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "solid-color" }
-  attrs: { name: "solid-opacity" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "SVG"
-  attrs: { name: "contentscripttype" }
-  attrs: { name: "contentstyletype" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "preserveaspectratio" }
-  attrs: {
-    name: "version"
-    value: "1.0"
-    value: "1.1"
-  }
-  attrs: { name: "viewbox" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attrs: { name: "zoomandpan" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "SWITCH"
-  mandatory_ancestor: "SVG"
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "VIEW"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "preserveaspectratio" }
-  attrs: { name: "viewbox" }
-  attrs: { name: "viewtarget" }
-  attrs: { name: "zoomandpan" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-# Shapes
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "CIRCLE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "cx" }
-  attrs: { name: "cy" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "r" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "ELLIPSE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "cx" }
-  attrs: { name: "cy" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "rx" }
-  attrs: { name: "ry" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "LINE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attrs: { name: "x1" }
-  attrs: { name: "x2" }
-  attrs: { name: "y1" }
-  attrs: { name: "y2" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "POLYGON"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "points" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "POLYLINE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "points" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "RECT"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "rx" }
-  attrs: { name: "ry" }
-  attrs: { name: "sketch:type" }
-  attrs: { name: "transform" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-# Text
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "TEXT"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "dx" }
-  attrs: { name: "dy" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "lengthadjust" }
-  attrs: { name: "rotate" }
-  attrs: { name: "text-anchor" }
-  attrs: { name: "textlength" }
-  attrs: { name: "transform" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "TEXTPATH"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "method" }
-  attrs: { name: "spacing" }
-  attrs: { name: "startoffset" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "TREF"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "TSPAN"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "dx" }
-  attrs: { name: "dy" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "lengthadjust" }
-  attrs: { name: "rotate" }
-  attrs: { name: "textlength" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-# Rendering
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "CLIPPATH"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "clippathunits" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FILTER"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "filterres" }
-  attrs: { name: "filterunits" }
-  attrs: { name: "height" }
-  attrs: { name: "primitiveunits" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "HKERN"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "g1" }
-  attrs: { name: "g2" }
-  attrs: { name: "k" }
-  attrs: { name: "u1" }
-  attrs: { name: "u2" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "LINEARGRADIENT"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "gradienttransform" }
-  attrs: { name: "gradientunits" }
-  attrs: { name: "spreadmethod" }
-  attrs: { name: "x1" }
-  attrs: { name: "x2" }
-  attrs: { name: "y1" }
-  attrs: { name: "y2" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "MASK"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "maskcontentunits" }
-  attrs: { name: "maskunits" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "PATTERN"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "patterncontentunits" }
-  attrs: { name: "patterntransform" }
-  attrs: { name: "patternunits" }
-  attrs: { name: "preserveaspectratio" }
-  attrs: { name: "viewbox" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "RADIALGRADIENT"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "cx" }
-  attrs: { name: "cy" }
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "fr" }
-  attrs: { name: "fx" }
-  attrs: { name: "fy" }
-  attrs: { name: "gradienttransform" }
-  attrs: { name: "gradientunits" }
-  attrs: { name: "r" }
-  attrs: { name: "spreadmethod" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "STOP"
-  spec_name: "lineargradient > stop"
-  mandatory_ancestor: "LINEARGRADIENT"
-  attrs: { name: "offset" }
-  attrs: { name: "stop-color" }
-  attrs: { name: "stop-opacity" }
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "STOP"
-  spec_name: "radialgradient > stop"
-  mandatory_ancestor: "RADIALGRADIENT"
-  attrs: { name: "offset" }
-  attrs: { name: "stop-color" }
-  attrs: { name: "stop-opacity" }
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "VKERN"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "g1" }
-  attrs: { name: "g2" }
-  attrs: { name: "k" }
-  attrs: { name: "u1" }
-  attrs: { name: "u2" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-# Special
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "DEFS"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "transform" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "SYMBOL"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "preserveaspectratio" }
-  attrs: { name: "viewbox" }
-  attrs: { name: "width" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "USE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "externalresourcesrequired" }
-  attrs: { name: "height" }
-  attrs: { name: "transform" }
-  attrs: { name: "width" }
-  attrs: { name: "x" }
-  attrs: { name: "y" }
-  attr_lists: "svg-conditional-processing-attributes"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-# Filters
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FECOLORMATRIX"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "in" }
-  attrs: { name: "type" }
-  attrs: { name: "values" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-filter-primitive-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FECOMPOSITE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "in" }
-  attrs: { name: "in2" }
-  attrs: { name: "k1" }
-  attrs: { name: "k2" }
-  attrs: { name: "k3" }
-  attrs: { name: "k4" }
-  attrs: { name: "operator" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-filter-primitive-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FEFLOOD"
-  mandatory_ancestor: "SVG"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-filter-primitive-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FEGAUSSIANBLUR"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "edgemode" }
-  attrs: { name: "in" }
-  attrs: { name: "stddeviation" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-filter-primitive-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FEMERGE"
-  mandatory_ancestor: "SVG"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-filter-primitive-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FEMERGENODE"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "in" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "FEOFFSET"
-  mandatory_ancestor: "SVG"
-  attrs: { name: "dx" }
-  attrs: { name: "dy" }
-  attrs: { name: "in" }
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-filter-primitive-attributes"
-  attr_lists: "svg-presentation-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-# ARIA
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "DESC"
-  mandatory_ancestor: "SVG"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  tag_name: "TITLE"
-  spec_name: "svg title"
-  mandatory_ancestor: "SVG"
-  attr_lists: "svg-core-attributes"
-  attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
-}
+# See validator-svg.protoascii.
 
 # 4.8 Links
 # Links are a concept, rather than a tag. See tagspecs for "LINK", "A", etc.
@@ -3944,110 +3124,106 @@ tags: {
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
-# TODO(b/167681900): update documentation to cover these script release versions
-# TODO(b/173803451): allow module/nomodule tagspecs.
-#tags: {
-#  html_format: AMP
-#  enabled_by: "transformed"
-#  tag_name: "SCRIPT"
-#  spec_name: "amphtml module engine script"
-#  descriptive_name: "amphtml engine script"
-#  mandatory_alternatives: "amphtml engine script"
-#  unique: true
-#  mandatory_parent: "HEAD"
-#  satisfies: "amphtml module engine script"
-#  requires: "amphtml nomodule engine script"
-#  attr_lists: "nonce-attr"
-#  attr_lists: "amphtml-module-engine-attrs"
-#  attrs: {
-#    name: "src"
-#    mandatory: true
-#    value: "https://cdn.ampproject.org/v0.mjs"
-#    dispatch_key: NAME_VALUE_DISPATCH
-#  }
-#  cdata: {
-#    whitespace_only: true
-#  }
-#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
-#}
-# TODO(b/167681900): update documentation to cover these script release versions
-# TODO(b/173803451): allow module/nomodule tagspecs.
-#tags: {
-#  html_format: AMP
-#  enabled_by: "transformed"
-#  tag_name: "SCRIPT"
-#  spec_name: "amphtml nomodule engine script"
-#  descriptive_name: "amphtml engine script"
-#  mandatory_alternatives: "amphtml engine script"
-#  unique: true
-#  mandatory_parent: "HEAD"
-#  satisfies: "amphtml nomodule engine script"
-#  requires: "amphtml module engine script"
-#  attr_lists: "nonce-attr"
-#  attr_lists: "amphtml-nomodule-engine-attrs"
-#  attrs: {
-#    name: "src"
-#    mandatory: true
-#    value: "https://cdn.ampproject.org/v0.js"
-#    dispatch_key: NAME_VALUE_DISPATCH
-#  }
-#  cdata: {
-#    whitespace_only: true
-#  }
-#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
-#}
-# TODO(b/167681900): update documentation to cover these script release versions
-# TODO(b/173803451): allow module/nomodule tagspecs.
-#tags: {
-#  html_format: AMP
-#  enabled_by: "transformed"
-#  tag_name: "SCRIPT"
-#  spec_name: "amphtml module LTS engine script"
-#  descriptive_name: "amphtml engine script"
-#  mandatory_alternatives: "amphtml engine script"
-#  unique: true
-#  mandatory_parent: "HEAD"
-#  satisfies: "amphtml module LTS engine script"
-#  requires: "amphtml nomodule LTS engine script"
-#  attr_lists: "nonce-attr"
-#  attr_lists: "amphtml-module-engine-attrs"
-#  attrs: {
-#    name: "src"
-#    mandatory: true
-#    value: "https://cdn.ampproject.org/lts/v0.mjs"
-#    dispatch_key: NAME_VALUE_DISPATCH
-#  }
-#  cdata: {
-#    whitespace_only: true
-#  }
-#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
-#}
-# TODO(b/167681900): update documentation to cover these script release versions
-# TODO(b/173803451): allow module/nomodule tagspecs.
-#tags: {
-#  html_format: AMP
-#  enabled_by: "transformed"
-#  tag_name: "SCRIPT"
-#  spec_name: "amphtml nomodule LTS engine script"
-#  descriptive_name: "amphtml engine script"
-#  mandatory_alternatives: "amphtml engine script"
-#  unique: true
-#  mandatory_parent: "HEAD"
-#  satisfies: "amphtml nomodule LTS engine script"
-#  requires: "amphtml module LTS engine script"
-#  attr_lists: "nonce-attr"
-#  attr_lists: "amphtml-nomodule-engine-attrs"
-#  attrs: {
-#    name: "src"
-#    mandatory: true
-#    value: "https://cdn.ampproject.org/lts/v0.js"
-#    dispatch_key: NAME_VALUE_DISPATCH
-#  }
-#  cdata: {
-#    whitespace_only: true
-#  }
-#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
-#}
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "SCRIPT"
+  spec_name: "amphtml module engine script"
+  descriptive_name: "amphtml module engine script"
+  mandatory_alternatives: "amphtml engine script"
+  unique: true
+  mandatory_parent: "HEAD"
+  satisfies: "amphtml module engine script"
+  requires: "amphtml nomodule engine script"
+  attr_lists: "nonce-attr"
+  attr_lists: "amphtml-module-engine-attrs"
+  attrs: {
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/v0.mjs"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  cdata: {
+    whitespace_only: true
+  }
+  # TODO(b/167681900): update spec_url to cover these script release versions
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+}
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "SCRIPT"
+  spec_name: "amphtml nomodule engine script"
+  descriptive_name: "amphtml nomodule engine script"
+  mandatory_alternatives: "amphtml engine script"
+  unique: true
+  mandatory_parent: "HEAD"
+  satisfies: "amphtml nomodule engine script"
+  requires: "amphtml module engine script"
+  attr_lists: "nonce-attr"
+  attr_lists: "amphtml-nomodule-engine-attrs"
+  attrs: {
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/v0.js"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  cdata: {
+    whitespace_only: true
+  }
+  # TODO(b/167681900): update spec_url to cover these script release versions
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+}
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "SCRIPT"
+  spec_name: "amphtml module LTS engine script"
+  descriptive_name: "amphtml module LTS engine script"
+  mandatory_alternatives: "amphtml engine script"
+  unique: true
+  mandatory_parent: "HEAD"
+  satisfies: "amphtml module LTS engine script"
+  requires: "amphtml nomodule LTS engine script"
+  attr_lists: "nonce-attr"
+  attr_lists: "amphtml-module-engine-attrs"
+  attrs: {
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/lts/v0.mjs"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  cdata: {
+    whitespace_only: true
+  }
+  # TODO(b/167681900): update spec_url to cover these script release versions
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+}
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "SCRIPT"
+  spec_name: "amphtml nomodule LTS engine script"
+  descriptive_name: "amphtml nomdule LTS engine script"
+  mandatory_alternatives: "amphtml engine script"
+  unique: true
+  mandatory_parent: "HEAD"
+  satisfies: "amphtml nomodule LTS engine script"
+  requires: "amphtml module LTS engine script"
+  attr_lists: "nonce-attr"
+  attr_lists: "amphtml-nomodule-engine-attrs"
+  attrs: {
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/lts/v0.js"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  cdata: {
+    whitespace_only: true
+  }
+  # TODO(b/167681900): update spec_url to cover these script release versions
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+}
 tags: {
   html_format: AMP4EMAIL
   tag_name: "SCRIPT"
@@ -4451,6 +3627,7 @@ tags: {  # <amp-img>
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
@@ -4520,6 +3697,10 @@ tags: {
     }
     css_declaration: { name: "padding-top" }
   }
+  attrs: {
+    name: "i-amphtml-disable-ar"
+    value: ""
+  }
 }
 
 tags: {
@@ -4533,6 +3714,10 @@ tags: {
     value: "i-amphtml-sizer"
     mandatory: true
     dispatch_key: NAME_DISPATCH
+  }
+  attrs: {
+    name: "i-amphtml-disable-ar"
+    value: ""
   }
 }
 
@@ -6546,6 +5731,12 @@ error_formats {
   format: "Tag 'html' marked with attribute 'data-ampdevmode'. Validator "
           "will suppress errors regarding any other tag with this attribute."
 }
+error_formats {
+  code: AMP_EMAIL_MISSING_STRICT_CSS_ATTR
+  format: "Tag 'html' marked with attribute 'amp4email' is missing the "
+          "corresponding attribute 'data-css-strict' for enabling strict "
+          "CSS validation. This may become an error in the future."
+}
 #
 # Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 #
@@ -6577,6 +5768,7 @@ declaration_list {
   declaration: { name: "animation-name" }
   declaration: { name: "animation-play-state" }
   declaration: { name: "animation-timing-function" }
+  declaration: { name: "aspect-ratio" }
   declaration: { name: "backface-visibility" }
   declaration: { name: "background" }
   declaration: { name: "background-attachment" }
@@ -6848,11 +6040,6 @@ declaration_list {
 }
 
 declaration_list {
-  name: "AMP_ONLY_DECLARATIONS"
-  declaration: { name: "clip-path" }
-}
-
-declaration_list {
   name: "EMAIL_SPECIFIC_DECLARATIONS"
   # AMP4EMAIL supported properties:
   # https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-css/#supported-css-properties
@@ -6863,6 +6050,7 @@ declaration_list {
   declaration: { name: "align-items" }
   declaration: { name: "align-self" }
   declaration: { name: "appearance" }
+  declaration: { name: "aspect-ratio" }
   declaration: { name: "azimuth" }
   declaration: { name: "background" }
   declaration: { name: "background-attachment" }
@@ -7122,11 +6310,7 @@ css {
   "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: true
 
-  # This is a legacy requirement. Style tags support all declarations while
-  # style attributes limit the allowed declarations. Support for style
-  # attributes was added at a later date than style tags, and more validation
-  # requirements were able to be enforced at that time.
-  allow_all_declaration_in_style_tag: true
+  allow_all_declaration_in_style: true
   allow_important: false
   image_url_spec: {
     protocol: "https"
@@ -7141,9 +6325,6 @@ css {
     allow_empty: true
   }
   expand_vendor_prefixes: true
-  declaration_list: "BASIC_DECLARATIONS"
-  declaration_list_svg: "SVG_BASIC_DECLARATIONS"
-  declaration_list: "AMP_ONLY_DECLARATIONS"
 }
 
 # DocCss Rules for AMP transformed documents.
@@ -7154,13 +6335,13 @@ css {
   enabled_by: "transformed"
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
-  max_bytes: 75000
-  max_bytes_per_inline_style: 1000
+  max_bytes: 112500
+  max_bytes_per_inline_style: 1500
   max_bytes_spec_url:
   "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: false
 
-  allow_all_declaration_in_style_tag: true
+  allow_all_declaration_in_style: true
   allow_important: false
   image_url_spec: {
     protocol: "https"
@@ -7175,9 +6356,6 @@ css {
     allow_empty: true
   }
   expand_vendor_prefixes: true
-  declaration_list: "BASIC_DECLARATIONS"
-  declaration_list_svg: "SVG_BASIC_DECLARATIONS"
-  declaration_list: "AMP_ONLY_DECLARATIONS"
 }
 
 # DocCss rules for AMP4ADS.
@@ -7191,7 +6369,7 @@ css {
   # max_bytes_per_inline_style: 1000
   max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec/#css"
 
-  allow_all_declaration_in_style_tag: true
+  allow_all_declaration_in_style: true
   allow_important: false
   image_url_spec: {
     protocol: "https"
@@ -7206,8 +6384,6 @@ css {
     allow_empty: true
   }
   expand_vendor_prefixes: true
-  declaration_list: "BASIC_DECLARATIONS"
-  declaration_list_svg: "SVG_BASIC_DECLARATIONS"
 }
 
 # DocCss rules for AMP4EMAIL, not data-css-strict
@@ -7227,11 +6403,7 @@ css {
   "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: true
 
-  # This is a legacy requirement. Style tags support all declarations while
-  # style attributes limit the allowed declarations. Support for style
-  # attributes was added at a later date than style tags, and more validation
-  # requirements were able to be enforced at that time.
-  allow_all_declaration_in_style_tag: true
+  allow_all_declaration_in_style: true
   allow_important: false
   image_url_spec: {
     protocol: "https"
@@ -7256,7 +6428,7 @@ css {
   "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: true
 
-  allow_all_declaration_in_style_tag: false
+  allow_all_declaration_in_style: false
   allow_important: false
   image_url_spec: {
     protocol: "https"
@@ -7330,9 +6502,87 @@ tags: {  # <style amp-custom>, [AMP]
     css_spec: {
       at_rule_spec: { name: 'font-face' }
       at_rule_spec: { name: 'keyframes' }
-      at_rule_spec: { name: 'media' }
+      at_rule_spec: {
+         name: 'media'
+         media_query_spec: {
+           issues_as_error: false
+           type: 'all'
+           type: 'print'
+           type: 'screen'
+           type: 'speech'
+           type: 'tty'
+           type: 'tv'
+           type: 'projection'
+           type: 'handheld'
+           type: 'braille'
+           type: 'embossesd'
+           type: 'aural'
+           feature: 'any-hover'
+           feature: 'any-pointer'
+           feature: 'aspect-ratio'
+           feature: 'color'
+           feature: 'color-gamut'
+           feature: 'color-index'
+           feature: 'device-aspect-ratio'
+           feature: 'device-height'
+           feature: 'device-width'
+           feature: 'display-mode'
+           feature: 'forced-colors'
+           feature: 'grid'
+           feature: 'height'
+           feature: 'hover'
+           feature: 'inverted-colors'
+           feature: 'light-level'
+           feature: 'max-aspect-ratio'
+           feature: 'max-color-index'
+           feature: 'max-device-aspect-ratio'
+           feature: 'max-device-height'
+           feature: 'max-device-width'
+           feature: 'max-height'
+           feature: 'max-resolution'
+           feature: 'max-width'
+           feature: 'min-aspect-ratio'
+           feature: 'min-color-index'
+           feature: 'min-device-aspect-ratio'
+           feature: 'min-device-height'
+           feature: 'min-device-width'
+           feature: 'min-height'
+           feature: 'min-resolution'
+           feature: 'min-width'
+           feature: 'monochrome'
+           feature: 'orientation'
+           feature: 'overflow-block'
+           feature: 'overflow-inline'
+           feature: 'pointer'
+           feature: 'prefers-color-scheme'
+           feature: 'prefers-contrast'
+           feature: 'prefers-reduced-motion'
+           feature: 'prefers-reduced-transparency'
+           feature: 'resolution'
+           feature: 'scan'
+           feature: 'scripting'
+           feature: 'transform-3d'
+           feature: 'update'
+           feature: 'width'
+           # Other non-standard media types and features commonly seen:
+           type: '-sass-debug-info'
+           type: 'device-pixel-ratio'
+           type: 'device-pixel-ratio2'
+           feature: '--mod'
+           feature: '--md'
+           feature: 'device-pixel-ratio'
+           feature: 'device-pixel-ratio2'
+           feature: 'high-contrast'
+           feature: 'max-device-pixel-ratio'
+           feature: 'min-device-pixel-ratio'
+           feature: 'max-device-pixel-ratio2'
+           feature: 'min-device-pixel-ratio2'
+         }
+      }
       at_rule_spec: { name: 'page' }
       at_rule_spec: { name: 'supports' }
+      # https://github.com/ampproject/amphtml/issues/26406
+      at_rule_spec: { name: '-moz-document' }
     }
     disallowed_cdata_regex: {
       regex: "<!--"
@@ -7776,7 +7026,85 @@ tags: {  # `<style amp-keyframes>`, [AMP, AMP4ADS]
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#keyframes-stylesheet"
     css_spec: {
       at_rule_spec: { name: 'keyframes' }
-      at_rule_spec: { name: 'media' }
+      at_rule_spec: {
+         name: 'media'
+         media_query_spec: {
+           issues_as_error: false
+           type: 'all'
+           type: 'print'
+           type: 'screen'
+           type: 'speech'
+           type: 'tty'
+           type: 'tv'
+           type: 'projection'
+           type: 'handheld'
+           type: 'braille'
+           type: 'embossesd'
+           type: 'aural'
+           feature: 'any-hover'
+           feature: 'any-pointer'
+           feature: 'aspect-ratio'
+           feature: 'color'
+           feature: 'color-gamut'
+           feature: 'color-index'
+           feature: 'device-aspect-ratio'
+           feature: 'device-height'
+           feature: 'device-width'
+           feature: 'display-mode'
+           feature: 'forced-colors'
+           feature: 'grid'
+           feature: 'height'
+           feature: 'hover'
+           feature: 'inverted-colors'
+           feature: 'light-level'
+           feature: 'monochrome'
+           feature: 'max-aspect-ratio'
+           feature: 'max-color-index'
+           feature: 'max-device-aspect-ratio'
+           feature: 'max-device-height'
+           feature: 'max-device-width'
+           feature: 'max-height'
+           feature: 'max-resolution'
+           feature: 'max-width'
+           feature: 'min-aspect-ratio'
+           feature: 'min-color-index'
+           feature: 'min-device-aspect-ratio'
+           feature: 'min-device-height'
+           feature: 'min-device-width'
+           feature: 'min-height'
+           feature: 'min-resolution'
+           feature: 'min-width'
+           feature: 'orientation'
+           feature: 'overflow-block'
+           feature: 'overflow-inline'
+           feature: 'pointer'
+           feature: 'prefers-color-scheme'
+           feature: 'prefers-contrast'
+           feature: 'prefers-reduced-motion'
+           feature: 'prefers-reduced-transparency'
+           feature: 'resolution'
+           feature: 'scan'
+           feature: 'scripting'
+           feature: 'transform-3d'
+           feature: 'update'
+           feature: 'width'
+           # Other non-standard media types and features commonly seen:
+           type: '-sass-debug-info'
+           type: 'device-pixel-ratio'
+           type: 'device-pixel-ratio2'
+           feature: '--mod'
+           feature: '--md'
+           feature: 'device-pixel-ratio'
+           feature: 'device-pixel-ratio2'
+           feature: 'high-contrast'
+           feature: 'aspect-ratio'
+           feature: 'max-device-pixel-ratio'
+           feature: 'min-device-pixel-ratio'
+           feature: 'max-device-pixel-ratio2'
+           feature: 'min-device-pixel-ratio2'
+         }
+      }
+
       at_rule_spec: { name: 'supports' }
       validate_keyframes: true
       declaration: "animation-timing-function"
@@ -8372,6 +7700,7 @@ tags: {  # amp-story-player
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
+  spec_url: "https://amp.dev/documentation/components/amp-story-player/"
 }
 tags: {  # <amp-story-player>
   html_format: AMP
@@ -8386,12 +7715,83 @@ tags: {  # <amp-story-player>
     supported_layouts: RESPONSIVE
     supported_layouts: INTRINSIC
   }
+  spec_url: "https://amp.dev/documentation/components/amp-story-player/"
 }
 descendant_tag_list {
   name: "amp-story-player-allowed-descendants"
   tag: "A"
   tag: "SPAN"
   tag: "I-AMPHTML-SIZER"  # Only allowed when document is transformed AMP
+  tag: "IMG"  # Only allowed when document is transformed AMP
+}
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "IMG"
+  spec_name: "img-i-amphtml-intrinsic-sizer-amp-story-player"
+  mandatory_parent: "I-AMPHTML-SIZER-INTRINSIC"
+  mandatory_ancestor: "AMP-STORY-PLAYER"
+  attrs: {
+    name: "alt"
+    value: ""
+    mandatory: true
+  }
+  attrs: {
+    name: "aria-hidden"
+    value: "true"
+    mandatory: true
+  }
+  attrs: {
+    name: "class"
+    value: "i-amphtml-intrinsic-sizer"
+    mandatory: true
+  }
+  attrs: {
+    name: "role"
+    value: "presentation"
+    mandatory: true
+  }
+  attrs: {
+    name: "src"
+    value_regex: "data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height=\"\\d+(\\.\\d+)?\" width=\"\\d+(\\.\\d+)?\" xmlns=\"http:\\/\\/www\\.w3\\.org\\/2000\\/svg\" version=\"1\\.1\"\\/>|data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height='\\d+(\\.\\d+)?\' width='\\d+(\\.\\d+)?\' xmlns='http:\\/\\/www\\.w3\\.org\\/2000\\/svg' version='1\\.1'\\/>|data:image\\/svg\\+xml;base64,[a-zA-Z0-9+\\/=]+"
+    mandatory: true
+  }
+  spec_url: "https://amp.dev/documentation/components/amp-story-player/"
+}
+tags: {
+  html_format: AMP
+  tag_name: "IMG"
+  spec_name: "amp-story-player > img"
+  mandatory_parent: "A"
+  mandatory_ancestor: "AMP-STORY-PLAYER"
+  attrs: { name: "alt" }
+  attrs: { name: "attribution" }
+  attrs: {
+    name: "data-amp-story-player-poster-img"
+    mandatory: true
+    value: ""
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+    attrs: {
+    name: "decoding"
+    value: "async"
+  }
+  attrs: {
+    name: "height"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "loading"
+    mandatory: true
+    value: "lazy"
+  }
+  attrs: { name: "sizes" }
+  attrs: {
+    name: "width"
+    value_regex: "[0-9]+"
+  }
+  attr_lists: "mandatory-src-or-srcset"
+  spec_url: "https://amp.dev/documentation/components/amp-story-player/"
 }
 #
 # Copyright 2016 The AMP HTML Authors. All Rights Reserved.
@@ -8571,6 +7971,11 @@ attr_lists: {
     name: "auto-advance-loops"
     # Media query / positive integer pairs
     value_regex: "([^,]+\\s+(\\d+),\\s*)*(\\d+)"
+  }
+  attrs: {
+    name: "controls"
+    # Media query / (always|auto|never)
+    value_regex: "([^,]+\\s+(always|auto|never),\\s*)*(always|auto|never)"
   }
   attrs: {
     name: "horizontal"
@@ -8892,6 +8297,8 @@ tags: {  # <amp-ad>
   attrs: { name: "template" }
   attrs: { name: "type" mandatory: true }
   attrs: { name: "sticky" value: "" }
+  attrs: { name: "always-serve-npa" }
+  attrs: { name: "block-rtc" }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
@@ -8973,6 +8380,8 @@ tags: {  # <amp-ad data-multi-size>
     }
     disallowed_value_regex: "__amp_source_origin"
   }
+  attrs: { name: "always-serve-npa" }
+  attrs: { name: "block-rtc" }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad/"
@@ -9050,6 +8459,8 @@ tags: {  # <amp-embed>
     disallowed_value_regex: "__amp_source_origin"
   }
   attrs: { name: "type" mandatory: true }
+  attrs: { name: "always-serve-npa" }
+  attrs: { name: "block-rtc" }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
@@ -9085,6 +8496,8 @@ tags: {  # <amp-embed data-multi-size>
   }
   attrs: { name: "json" }
   attrs: { name: "rtc-config" }
+  attrs: { name: "always-serve-npa" }
+  attrs: { name: "block-rtc" }
   attrs: {
     name: "src"
     value_url: {
@@ -12509,6 +11922,42 @@ tags: {  # amp-autocomplete JSON
   }
 }
 #
+# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-story-auto-analytics
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-story-auto-analytics"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-story-auto-analytics>
+  html_format: AMP
+  tag_name: "AMP-STORY-AUTO-ANALYTICS"
+  requires_extension: "amp-story-auto-analytics"
+  attrs: {
+    name: "gtag-id"
+    mandatory: true
+    value_regex: "[A-Z]{1,2}-[A-Z0-9-]+"
+  }
+}
+#
 # Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14398,6 +13847,7 @@ tags: {  # <amp-story>
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-SIDEBAR"
     child_tag_name_oneof: "AMP-STORY-AUTO-ADS"
+    child_tag_name_oneof: "AMP-STORY-AUTO-ANALYTICS"
     child_tag_name_oneof: "AMP-STORY-BOOKEND"
     child_tag_name_oneof: "AMP-STORY-PAGE"
   }
@@ -14422,6 +13872,7 @@ tags: {  # <amp-story-page>
     child_tag_name_oneof: "AMP-ANALYTICS"
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-STORY-ANIMATION"
+    child_tag_name_oneof: "AMP-STORY-AUTO-ANALYTICS"
     child_tag_name_oneof: "AMP-STORY-CTA-LAYER"
     child_tag_name_oneof: "AMP-STORY-GRID-LAYER"
     child_tag_name_oneof: "AMP-STORY-PAGE-ATTACHMENT"
@@ -14433,12 +13884,12 @@ tags: {  # <amp-story-grid-layer>
   tag_name: "AMP-STORY-GRID-LAYER"
   mandatory_ancestor: "AMP-STORY-PAGE"
   attrs: {
-    name: "template"
-    mandatory: true
-    value: "fill"
-    value: "horizontal"
-    value: "thirds"
-    value: "vertical"
+    name: "anchor"
+    value_regex: "top|bottom|left|right|(top|bottom)[ -](left|right)|(left|right)[ -](top|bottom)"
+  }
+  attrs: {
+    name: "aspect-ratio"
+    value_regex: "\\d+:\\d+"
   }
   attrs: {
     name: "position"
@@ -14446,8 +13897,17 @@ tags: {  # <amp-story-grid-layer>
     value: "landscape-half-right"
   }
   attrs: {
-    name: "aspect-ratio"
-    value_regex: "\\d+:\\d+"
+    name: "preset"
+    value: "2021-background"
+    value: "2021-foreground"
+  }
+  attrs: {
+    name: "template"
+    mandatory: true
+    value: "fill"
+    value: "horizontal"
+    value: "thirds"
+    value: "vertical"
   }
   descendant_tag_list: "amp-story-grid-layer-allowed-descendants"
   reference_points: {
@@ -14938,6 +14398,7 @@ descendant_tag_list: {
   tag: "AMP-PIXEL"
   tag: "AMP-STATE"
   tag: "AMP-STORY-360"
+  tag: "AMP-STORY-AUTO-ANALYTICS"
   tag: "AMP-STORY-INTERACTIVE-BINARY-POLL"
   tag: "AMP-STORY-INTERACTIVE-POLL"
   tag: "AMP-STORY-INTERACTIVE-QUIZ"
@@ -18315,8 +17776,9 @@ tags: {  # <amp-bodymovin-animation>
   }
   attrs: {
     name: "renderer"
-    value_casei: "svg"
+    value_casei: "canvas"
     value_casei: "html"
+    value_casei: "svg"
   }
   spec_url: "https://amp.dev/documentation/components/amp-bodymovin-animation/"
   amp_layout: {
@@ -18683,6 +18145,68 @@ tags: {  # <amp-analytics>
   attrs: { name: "type" }
   spec_url: "https://amp.dev/documentation/components/amp-analytics/"
 }
+#
+# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-google-assistant-assistjs
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-google-assistant-assistjs"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-google-assistant-assistjs-config>
+  html_format: AMP
+  tag_name: "AMP-GOOGLE-ASSISTANT-ASSISTJS-CONFIG"
+  requires_extension: "amp-google-assistant-assistjs"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+}
+tags: {  # <amp-google-assistant-voice-button>
+  html_format: AMP
+  tag_name: "AMP-GOOGLE-ASSISTANT-VOICE-BUTTON"
+  requires_extension: "amp-google-assistant-assistjs"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-google-assistant-voice-bar>
+  html_format: AMP
+  tag_name: "AMP-GOOGLE-ASSISTANT-VOICE-BAR"
+  requires_extension: "amp-google-assistant-assistjs"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-google-assistant-inline-suggestion-bar>
+  html_format: AMP
+  tag_name: "AMP-GOOGLE-ASSISTANT-INLINE-SUGGESTION-BAR"
+  requires_extension: "amp-google-assistant-assistjs"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: RESPONSIVE
+  }
+}
+
 #
 # Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 #

--- a/src/test/java/dev/amp/validator/ContextTest.java
+++ b/src/test/java/dev/amp/validator/ContextTest.java
@@ -311,7 +311,7 @@ public class ContextTest {
         Assert.assertEquals(context.getInlineStyleByteSize(), 40);
     }
 
-    private int MAX_BODY_LENGTH = 100000;
+    private final int MAX_BODY_LENGTH = 100000;
 
     private ParsedValidatorRules mockValidatorRules;
     private static final String UPPER_NAME = "HEAD";

--- a/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
+++ b/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
@@ -49,7 +49,7 @@ public class AMPHtmlParserTest {
       final int maxNode = 10000;
       ValidatorProtos.ValidationResult result =
               ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
-      Assert.assertEquals(result.getErrorsCount(), 0, "Expecting to have 0 error");
+      Assert.assertTrue(onlyErrorIsWarning(result));
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -65,6 +65,7 @@ public class AMPHtmlParserTest {
       ValidatorProtos.ValidationResult result =
               ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 0, "Expecting to have 0 error");
+      Assert.assertEquals(result.getStatus(), ValidatorProtos.ValidationResult.Status.PASS);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -80,6 +81,7 @@ public class AMPHtmlParserTest {
       ValidatorProtos.ValidationResult result =
               ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 0, "Expecting to have 0 error");
+      Assert.assertEquals(result.getStatus(), ValidatorProtos.ValidationResult.Status.PASS);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -94,6 +96,7 @@ public class AMPHtmlParserTest {
       final int maxNode = 10000;
       ValidatorProtos.ValidationResult result =
               ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
+      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_ATTR);
       Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
@@ -109,6 +112,7 @@ public class AMPHtmlParserTest {
       final int maxNode = 10000;
       ValidatorProtos.ValidationResult result =
               ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.EXIT_ON_FIRST_ERROR, maxNode);
+      Assert.assertEquals(result.getErrorsCount(), 0, "Expecting to have 0 error");
       Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.PASS);
     } catch (final IOException ex) {
       ex.printStackTrace();
@@ -154,6 +158,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_TAG);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -170,6 +175,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_SCRIPT_TAG);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -186,6 +192,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DUPLICATE_UNIQUE_TAG);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -202,6 +209,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.WRONG_PARENT_TAG);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -218,6 +226,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_TAG_ANCESTOR);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -239,6 +248,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.MANDATORY_TAG_ANCESTOR);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -260,6 +270,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INCORRECT_NUM_CHILD_TAGS);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -281,6 +292,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_CHILD_TAG_NAME);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -297,6 +309,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_FIRST_CHILD_TAG_NAME);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -353,8 +366,10 @@ public class AMPHtmlParserTest {
       final int maxNode = 10000;
       ValidatorProtos.ValidationResult result =
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
-      Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
-      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.MISSING_REQUIRED_EXTENSION);
+      Assert.assertEquals(result.getErrorsCount(), 2, "Expecting to have 2 error");
+      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.AMP_EMAIL_MISSING_STRICT_CSS_ATTR);
+      Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.MISSING_REQUIRED_EXTENSION);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -371,6 +386,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.SPECIFIED_LAYOUT_INVALID);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -388,6 +404,7 @@ public class AMPHtmlParserTest {
       Assert.assertEquals(result.getErrorsCount(), 2, "Expecting to have 2 errors");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_TAG_ANCESTOR);
       Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.TAG_REFERENCE_POINT_CONFLICT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -404,6 +421,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DEPRECATED_TAG);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -420,6 +438,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.EXTENSION_UNUSED);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -436,6 +455,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.NON_WHITESPACE_CDATA_ENCOUNTERED);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -453,6 +473,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.MANDATORY_CDATA_MISSING_OR_INCORRECT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -469,6 +490,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INVALID_JSON_CDATA);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -488,6 +510,7 @@ public class AMPHtmlParserTest {
       Assert.assertEquals(result.getErrorsCount(), 2, "Expecting to have 2 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_ATTR);
       Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.MANDATORY_ATTR_MISSING);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
       // TODO : write a containsError helper method
     } catch (final IOException ex) {
       ex.printStackTrace();
@@ -505,6 +528,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INVALID_ATTR_VALUE);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -538,6 +562,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.MANDATORY_ATTR_MISSING);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -554,6 +579,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.ATTR_MISSING_REQUIRED_EXTENSION);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -573,6 +599,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.TEMPLATE_IN_ATTR_NAME);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
       //Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.TEMPLATE_IN_ATTR_NAME);
     } catch (final IOException ex) {
       ex.printStackTrace();
@@ -590,6 +617,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.UNESCAPED_TEMPLATE_IN_ATTR_VALUE);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -606,6 +634,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.TEMPLATE_PARTIAL_IN_ATTR_VALUE);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -622,6 +651,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.MISSING_LAYOUT_ATTRIBUTES);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -638,6 +668,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -654,6 +685,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.ATTR_DISALLOWED_BY_IMPLIED_LAYOUT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -670,6 +702,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.ATTR_VALUE_REQUIRED_BY_LAYOUT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -702,6 +735,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -718,6 +752,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.ATTR_REQUIRED_BUT_MISSING);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -734,6 +769,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_PROPERTY_IN_ATTR_VALUE);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -750,6 +786,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.MISSING_URL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -766,6 +803,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DISALLOWED_RELATIVE_URL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -782,6 +820,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INVALID_URL_PROTOCOL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -802,6 +841,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.STYLESHEET_TOO_LONG);
       Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.DOCUMENT_SIZE_LIMIT_EXCEEDED);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
       Assert.assertEquals(result.getErrorsCount(), 2, "Expecting to have 2 error.");
     } catch (final IOException ex) {
       ex.printStackTrace();
@@ -819,6 +859,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INLINE_STYLE_TOO_LONG);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -835,6 +876,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_UNTERMINATED_COMMENT);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -855,7 +897,7 @@ public class AMPHtmlParserTest {
       Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_UNTERMINATED_STRING);
       Assert.assertTrue(result.getErrors(2).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_DECLARATION);
       Assert.assertTrue(result.getErrors(3).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_DECLARATION);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -875,6 +917,7 @@ public class AMPHtmlParserTest {
         == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_STRAY_TRAILING_BACKSLASH);
       Assert.assertTrue(result.getErrors(1).getCode()
         == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_DECLARATION);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -891,7 +934,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_DECLARATION);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -908,7 +951,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INCOMPLETE_DECLARATION);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -925,7 +968,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_MEDIA_TYPE);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -942,7 +985,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -962,6 +1005,7 @@ public class AMPHtmlParserTest {
       Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_AT_RULE);
       Assert.assertTrue(result.getErrors(2).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_AT_RULE);
       Assert.assertTrue(result.getErrors(3).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_AT_RULE);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -978,7 +1022,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_MALFORMED_MEDIA_QUERY);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -995,7 +1039,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error.");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE);
-
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1012,6 +1056,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_MISSING_URL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1028,6 +1073,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_BAD_URL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1044,6 +1090,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_EXCESSIVELY_NESTED);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1076,6 +1123,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_INVALID_URL_PROTOCOL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1110,6 +1158,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.WARNING_EXTENSION_DEPRECATED_VERSION);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1144,6 +1193,11 @@ public class AMPHtmlParserTest {
       }
     }
     return sb.toString();
+  }
+
+  public static boolean onlyErrorIsWarning(final ValidatorProtos.ValidationResult result) {
+    return (result.getErrorsCount() == 1 && result.getErrors(0).getCode()
+            == ValidatorProtos.ValidationError.Code.AMP_EMAIL_MISSING_STRICT_CSS_ATTR);
   }
 
   /**

--- a/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
+++ b/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
@@ -421,7 +421,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.DEPRECATED_TAG);
-      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.PASS);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -490,7 +490,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.INVALID_JSON_CDATA);
-      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.PASS);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }
@@ -1158,7 +1158,7 @@ public class AMPHtmlParserTest {
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
       Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.WARNING_EXTENSION_DEPRECATED_VERSION);
-      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.PASS);
     } catch (final IOException ex) {
       ex.printStackTrace();
     }

--- a/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
+++ b/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
@@ -1088,8 +1088,9 @@ public class AMPHtmlParserTest {
       final int maxNode = 10000;
       ValidatorProtos.ValidationResult result =
         ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
-      Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
+      Assert.assertEquals(result.getErrorsCount(), 2, "Expecting to have 2 error");
       Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CSS_EXCESSIVELY_NESTED);
+      Assert.assertTrue(result.getErrors(1).getCode() == ValidatorProtos.ValidationError.Code.CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR);
       Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.FAIL);
     } catch (final IOException ex) {
       ex.printStackTrace();

--- a/src/test/resources/test-cases/attributes/testAttrDisallowedByImpliedLayout.html
+++ b/src/test/resources/test-cases/attributes/testAttrDisallowedByImpliedLayout.html
@@ -2,7 +2,7 @@
      ATTR_DISALLOWED_BY_IMPLIED_LAYOUT
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testAttrDisallowedBySpecifiedLayout.html
+++ b/src/test/resources/test-cases/attributes/testAttrDisallowedBySpecifiedLayout.html
@@ -2,7 +2,7 @@
      ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testAttrMissingRequiredExtension.html
+++ b/src/test/resources/test-cases/attributes/testAttrMissingRequiredExtension.html
@@ -2,7 +2,7 @@
      ATTR_MISSING_REQUIRED_EXTENSION
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testAttrRequiredButMissing.html
+++ b/src/test/resources/test-cases/attributes/testAttrRequiredButMissing.html
@@ -2,7 +2,7 @@
      ATTR_REQUIRED_BUT_MISSING
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testAttrValueRequiredByLayout.html
+++ b/src/test/resources/test-cases/attributes/testAttrValueRequiredByLayout.html
@@ -2,7 +2,7 @@
      ATTR_VALUE_REQUIRED_BY_LAYOUT
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testDisallowedPropertyInAttrValue.html
+++ b/src/test/resources/test-cases/attributes/testDisallowedPropertyInAttrValue.html
@@ -2,7 +2,7 @@
   DISALLOWED_PROPERTY_IN_ATTR_VALUE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testDisallowedRelativeUrl.html
+++ b/src/test/resources/test-cases/attributes/testDisallowedRelativeUrl.html
@@ -2,7 +2,7 @@
      DISALLOWED_RELATIVE_URL
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testInconsistentUnitsForWidthAndHeight.html
+++ b/src/test/resources/test-cases/attributes/testInconsistentUnitsForWidthAndHeight.html
@@ -2,7 +2,7 @@
      INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testInvalidAttrValue.html
+++ b/src/test/resources/test-cases/attributes/testInvalidAttrValue.html
@@ -2,7 +2,7 @@
      INVALID_ATTR_VALUE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <meta name="viewport">

--- a/src/test/resources/test-cases/attributes/testInvalidUrlProtocol.html
+++ b/src/test/resources/test-cases/attributes/testInvalidUrlProtocol.html
@@ -2,7 +2,7 @@
      INVALID_URL_PROTOCOL
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 
 <head>
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/attributes/testMandatoryAttrMissing.html
+++ b/src/test/resources/test-cases/attributes/testMandatoryAttrMissing.html
@@ -2,7 +2,7 @@
      MANDATORY_ATTR_MISSING
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/attributes/testMissingLayoutAttributes.html
+++ b/src/test/resources/test-cases/attributes/testMissingLayoutAttributes.html
@@ -2,7 +2,7 @@
      MISSING_LAYOUT_ATTRIBUTES
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/attributes/testMissingUrl.html
+++ b/src/test/resources/test-cases/attributes/testMissingUrl.html
@@ -2,7 +2,7 @@
      MISSING_URL
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/css/testAmpSelectorsPASS.html
+++ b/src/test/resources/test-cases/css/testAmpSelectorsPASS.html
@@ -2,7 +2,7 @@
      AMP_SELECTORS_PASS
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/css/testCSSExcessivelyNested.html
+++ b/src/test/resources/test-cases/css/testCSSExcessivelyNested.html
@@ -2,7 +2,7 @@
      CSS_EXCESSIVELY_NESTED
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         i{width:

--- a/src/test/resources/test-cases/css/testCSSSyntaxBadUrl.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxBadUrl.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_BAD_URL
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaFeature.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaFeature.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaType.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxDisallowedMediaType.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_DISALLOWED_MEDIA_TYPE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxDisallowedPropertyValue.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxDisallowedPropertyValue.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxIncompleteDeclaration.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxIncompleteDeclaration.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_DECLARATION
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidAtRule.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidAtRule.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_INVALID_AT_RULE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidDeclaration.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidDeclaration.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_DECLARATION
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxInvalidUrlProtocol.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxInvalidUrlProtocol.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_INVALID_URL_PROTOCOL
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxMalformedMediaQuery.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxMalformedMediaQuery.html
@@ -2,7 +2,7 @@
   CSS_SYNTAX_MALFORMED_MEDIA_QUERY
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxMissingURL.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxMissingURL.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_MISSING_URL
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         ul {

--- a/src/test/resources/test-cases/css/testCSSSyntaxStrayTrailingBackslash.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxStrayTrailingBackslash.html
@@ -3,7 +3,7 @@
      "CSS syntax error in tag '...' - stray trailing backslash."
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         /* any custom styles go here. */

--- a/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedComment.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedComment.html
@@ -3,7 +3,7 @@
      "CSS syntax error in tag '...' - unterminated comment."
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         h1 { color: red; }

--- a/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedComment.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedComment.html
@@ -6,10 +6,7 @@
 <html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
-        h1 { color: red; }
-        @page :first {
-            margin: 1in;
-        }/*uhbuhbuyb
+        h1 { color: red; }  /*uhbuhbuyb
     </style>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedString.html
+++ b/src/test/resources/test-cases/css/testCSSSyntaxUnterminatedString.html
@@ -2,7 +2,7 @@
      CSS_SYNTAX_UNTERMINATED_STRING
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <style amp-custom>
         ul {"

--- a/src/test/resources/test-cases/css/testInlineStyleTooLong.html
+++ b/src/test/resources/test-cases/css/testInlineStyleTooLong.html
@@ -2,7 +2,8 @@
   INLINE_STYLE_TOO_LONG
 -->
 <!doctype html>
-<html ⚡4email>
+<html
+ ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testInlineStyleTooLong.html
+++ b/src/test/resources/test-cases/css/testInlineStyleTooLong.html
@@ -2,8 +2,7 @@
   INLINE_STYLE_TOO_LONG
 -->
 <!doctype html>
-<html
- ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/css/testStylesheetTooLong.html
+++ b/src/test/resources/test-cases/css/testStylesheetTooLong.html
@@ -19,7 +19,7 @@
   CSS_SYNTAX_INVALID_AT_RULE should be returned
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/misc/testWarningExtensionDeprecatedVersion.html
+++ b/src/test/resources/test-cases/misc/testWarningExtensionDeprecatedVersion.html
@@ -2,7 +2,7 @@
      WARNING_EXTENSION_DEPRECATED_VERSION
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/tags/testAmpCarousel.html
+++ b/src/test/resources/test-cases/tags/testAmpCarousel.html
@@ -2,7 +2,7 @@
      AMP-CAROUSEL
 -->
 <!doctype html>
-<html amp4email>
+<html data-css-strict amp4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testAmpList.html
+++ b/src/test/resources/test-cases/tags/testAmpList.html
@@ -2,7 +2,7 @@
      AMP-LIST
 -->
 <!doctype html>
-<html ⚡4email>
+<html ⚡4email data-css-strict>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testAmpTimeAgo.html
+++ b/src/test/resources/test-cases/tags/testAmpTimeAgo.html
@@ -2,7 +2,7 @@
      AMP-TIMEAGO
 -->
 <!doctype html>
-<html ⚡4email data-css-strict>
+<html ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testDeprecatedTag.html
+++ b/src/test/resources/test-cases/tags/testDeprecatedTag.html
@@ -2,7 +2,7 @@
      DEPRECATED_TAG
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <title>Hello, AMPs</title>
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/tags/testDisallowedChildTagName.html
+++ b/src/test/resources/test-cases/tags/testDisallowedChildTagName.html
@@ -2,7 +2,7 @@
      DISALLOWED_CHILD_TAG_NAME
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testDisallowedFirstChildTagName.html
+++ b/src/test/resources/test-cases/tags/testDisallowedFirstChildTagName.html
@@ -2,7 +2,7 @@
      DISALLOWED_FIRST_CHILD_TAG_NAME
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testDisallowedScriptTag.html
+++ b/src/test/resources/test-cases/tags/testDisallowedScriptTag.html
@@ -2,7 +2,7 @@
      DISALLOWED_SCRIPT_TAG
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <meta name="viewport1">

--- a/src/test/resources/test-cases/tags/testDisallowedTag.html
+++ b/src/test/resources/test-cases/tags/testDisallowedTag.html
@@ -2,7 +2,7 @@
      DISALLOWED_TAG
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -11,5 +11,7 @@
 <body>
 Hello, AMP4EMAIL world.
 <not_a_tag></not_a_tag>
+<div>
+</div>
 </body>
 </html>

--- a/src/test/resources/test-cases/tags/testDisallowedTagAncestor.html
+++ b/src/test/resources/test-cases/tags/testDisallowedTagAncestor.html
@@ -2,7 +2,7 @@
      DISALLOWED_TAG_ANCESTOR
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>

--- a/src/test/resources/test-cases/tags/testDuplicateUniqueTag.html
+++ b/src/test/resources/test-cases/tags/testDuplicateUniqueTag.html
@@ -2,7 +2,7 @@
      DUPLICATE_UNIQUE_TAG
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/tags/testExtensionUnused.html
+++ b/src/test/resources/test-cases/tags/testExtensionUnused.html
@@ -2,7 +2,7 @@
      EXTENSION_UNUSED
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testIncorrectNumChildTags.html
+++ b/src/test/resources/test-cases/tags/testIncorrectNumChildTags.html
@@ -2,7 +2,7 @@
      INCORRECT_NUM_CHILD_TAGS
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testInvalidJsonCdata.html
+++ b/src/test/resources/test-cases/tags/testInvalidJsonCdata.html
@@ -2,7 +2,7 @@
      INVALID_JSON_CDATA
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testMandatoryCdataMissingOrIncorrect.html
+++ b/src/test/resources/test-cases/tags/testMandatoryCdataMissingOrIncorrect.html
@@ -2,7 +2,7 @@
   MANDATORY_CDATA_MISSING_OR_INCORRECT
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <style amp4email-boilerplate></style>

--- a/src/test/resources/test-cases/tags/testMandatoryTagAncestor.html
+++ b/src/test/resources/test-cases/tags/testMandatoryTagAncestor.html
@@ -2,7 +2,7 @@
      MANDATORY_TAG_ANCESTOR
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>

--- a/src/test/resources/test-cases/tags/testNonWhitespaceCdataEncountered.html
+++ b/src/test/resources/test-cases/tags/testNonWhitespaceCdataEncountered.html
@@ -2,7 +2,7 @@
      NON_WHITESPACE_CDATA_ENCOUNTERED
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 
 <head>
     <meta charset="utf-8">

--- a/src/test/resources/test-cases/tags/testSpecifiedLayoutInvalid.html
+++ b/src/test/resources/test-cases/tags/testSpecifiedLayoutInvalid.html
@@ -2,7 +2,7 @@
      SPECIFIED_LAYOUT_INVALID
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
+++ b/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
@@ -1,5 +1,5 @@
 <!--
-     TAG_REFERENCE_POINT_CONFLICT
+    TAG_REFERENCE_POINT_CONFLICT
 -->
 <!doctype html>
 <html data-css-strict ⚡4email>
@@ -7,38 +7,13 @@
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
-    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
-    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
     <style amp4email-boilerplate>body{visibility:hidden}</style>
-    <style amp-custom>
-        .radio-selector [option][selected] {
-            outline: none;
-        }
-        .radio-selector [option] {
-            display: flex;
-            align-items: center;
-        }
-        .radio-selector [option]:before {
-            transition: background 0.25s ease-in-out;
-            display: inline-block;
-            width: 24px;
-            height: 24px;
-            margin: .5rem;
-            border-radius: 100%;
-            border: solid 1px #005AF0;
-        }
-        .radio-selector [option][selected]:before {
-            text-align: center;
-            color: #fff;
-            background-color: #005AF0;
-        }
-    </style>
 </head>
 <body>
-<div>
-    <amp-selector layout="container" class="radio-selector">
-        <amp-selector></amp-selector>
-    </amp-selector>
-</div>
+<amp-selector layout="container" class="radio-selector">
+    <amp-selector></amp-selector>
+</amp-selector>
+
+Hello, AMP4EMAIL world.
 </body>
 </html>

--- a/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
+++ b/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
@@ -20,7 +20,6 @@
         }
         .radio-selector [option]:before {
             transition: background 0.25s ease-in-out;
-            content: "";
             display: inline-block;
             width: 24px;
             height: 24px;
@@ -30,7 +29,6 @@
         }
         .radio-selector [option][selected]:before {
             text-align: center;
-            content: "✓";
             color: #fff;
             background-color: #005AF0;
         }

--- a/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
+++ b/src/test/resources/test-cases/tags/testTagReferencePointConflict.html
@@ -2,7 +2,7 @@
      TAG_REFERENCE_POINT_CONFLICT
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testTransformedValueRe.html
+++ b/src/test/resources/test-cases/tags/testTransformedValueRe.html
@@ -2,7 +2,7 @@
      TRANSFORMED_VALUE
 -->
 <!doctype html>
-<html ⚡4email transformed="self;v=1">
+<html data-css-strict ⚡4email transformed="self;v=1">
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/tags/testWrongParentTag.html
+++ b/src/test/resources/test-cases/tags/testWrongParentTag.html
@@ -2,7 +2,7 @@
      WRONG_PARENT_TAG
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/test/resources/test-cases/templates/testTemplateInAttrName.html
+++ b/src/test/resources/test-cases/templates/testTemplateInAttrName.html
@@ -2,7 +2,7 @@
      TEMPLATE_IN_ATTR_NAME
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/templates/testTemplatePartialInAttrValue.html
+++ b/src/test/resources/test-cases/templates/testTemplatePartialInAttrValue.html
@@ -2,7 +2,7 @@
      TEMPLATE_PARTIAL_IN_ATTR_VALUE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>

--- a/src/test/resources/test-cases/templates/testUnescapedTemplateInAttrValue.html
+++ b/src/test/resources/test-cases/templates/testUnescapedTemplateInAttrValue.html
@@ -2,7 +2,7 @@
      UNESCAPED_TEMPLATE_IN_ATTR_VALUE
 -->
 <!doctype html>
-<html ⚡4email>
+<html data-css-strict ⚡4email>
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>  <style amp4email-boilerplate>body{visibility:hidden}</style>


### PR DESCRIPTION
- setValidationResultStatus was fixed, previously warnings would result in error denomination to final status
- implement changes to account for data-css-strict
- maybeSpec changes into maybeDocCssSpec (January 2021 catch-up)
- Some visitor code was missing in SelectorSpecVisitor InvalidDeclVisitor classes
- fix tests to account for changes


