### PR TITLE
trim token in isDelim method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>dev.amp</groupId>
     <artifactId>validator-java</artifactId>
     <name>AMP validator Java API</name>
-    <version>1.0.16</version>
+    <version>1.0.17</version>
     <description>A Java validator for the AMP Html format.</description>
     <packaging>jar</packaging>
     <url>https://github.com/ampproject/validator-java</url>

--- a/src/main/java/dev/amp/validator/utils/SelectorUtils.java
+++ b/src/main/java/dev/amp/validator/utils/SelectorUtils.java
@@ -104,7 +104,7 @@ public final class SelectorUtils {
      * @return if this is a delim char
      */
     public static boolean isDelim(@Nonnull final com.steadystate.css.parser.Token token, @Nonnull final String delimChar) {
-        return getTokenType(token) == TokenType.DELIM && (token.image).equals(delimChar);
+        return getTokenType(token) == TokenType.DELIM && (token.image.trim()).equals(delimChar);
     }
 
     /**

--- a/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
+++ b/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
@@ -845,6 +845,22 @@ public class AMPHtmlParserTest {
 
   // VALIDATION CSS
 
+  @Test
+  public void testDelimiterPASS() {
+    try {
+      String inputHtml =
+              readFile(
+                      "test-cases/css/testDelimiterPASS.html");
+      final int maxNode = 10000;
+      ValidatorProtos.ValidationResult result =
+              ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
+      Assert.assertEquals(result.getErrorsCount(), 0, "Expecting to have 2 error");
+      Assert.assertTrue(result.getStatus() == ValidatorProtos.ValidationResult.Status.PASS);
+    } catch (final IOException ex) {
+      ex.printStackTrace();
+    }
+  }
+
   // TODO: debugging indicates the CSS is tokenized before the length check. Should validate length before.
   @Test
   public void testStylesheetTooLong() {

--- a/src/test/resources/test-cases/css/testDelimiterPASS.html
+++ b/src/test/resources/test-cases/css/testDelimiterPASS.html
@@ -1,0 +1,18 @@
+<!--
+  verify delims are parsed correctly
+-->
+<!doctype html>
+<html data-css-strict amp4email>
+<head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <style amp4email-boilerplate>body{visibility:hidden}</style>
+    <style amp-custom>
+        .abtn input:checked + span{
+            background: #F5B705;
+        }
+    </style>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
" +" was not being considered a delimiter as it was not an exact match to "+". Now we trim all candidates for the isDelim function.